### PR TITLE
feat: add metadata-only Filter method to vector providers

### DIFF
--- a/api.go
+++ b/api.go
@@ -30,6 +30,7 @@ var (
 	ErrIndexNotReady        = shared.ErrIndexNotReady
 	ErrInvalidQuery         = shared.ErrInvalidQuery
 	ErrOperatorNotSupported = shared.ErrOperatorNotSupported
+	ErrFilterNotSupported   = shared.ErrFilterNotSupported
 )
 
 // StoreProvider defines raw key-value storage operations.
@@ -222,6 +223,12 @@ type VectorProvider interface {
 	// Returns ErrOperatorNotSupported if the provider doesn't support an operator.
 	Query(ctx context.Context, vector []float32, k int, filter *vecna.Filter) ([]VectorResult, error)
 
+	// Filter returns vectors matching the metadata filter without similarity search.
+	// Result ordering is provider-dependent and not guaranteed by the interface.
+	// Limit of 0 returns all matching vectors.
+	// Returns ErrFilterNotSupported if the provider cannot perform metadata-only filtering.
+	Filter(ctx context.Context, filter *vecna.Filter, limit int) ([]VectorResult, error)
+
 	// List returns vector IDs.
 	// Limit of 0 means no limit.
 	List(ctx context.Context, limit int) ([]uuid.UUID, error)
@@ -265,4 +272,7 @@ type AtomicIndex interface {
 
 	// Query performs similarity search with vecna filter support.
 	Query(ctx context.Context, vector []float32, k int, filter *vecna.Filter) ([]AtomicVector, error)
+
+	// Filter returns vectors matching the metadata filter without similarity search.
+	Filter(ctx context.Context, filter *vecna.Filter, limit int) ([]AtomicVector, error)
 }

--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -600,6 +600,22 @@ filter := vecna.And(
 results, err := index.Query(ctx, queryVector, 10, filter)
 ```
 
+#### Filter
+
+```go
+func (i *Index[T]) Filter(ctx context.Context, filter *vecna.Filter, limit int) ([]*Vector[T], error)
+```
+
+Returns vectors matching the metadata filter without similarity search. Result ordering is provider-dependent and not guaranteed by the interface. Limit of 0 returns all matching vectors. Returns `ErrFilterNotSupported` if the provider cannot perform metadata-only filtering (e.g., Pinecone).
+
+```go
+filter := vecna.Eq("category", "tech")
+results, err := index.Filter(ctx, filter, 100)
+
+// Nil filter returns all vectors
+all, err := index.Filter(ctx, nil, 0)
+```
+
 #### List
 
 ```go
@@ -768,6 +784,7 @@ type VectorProvider interface {
     DeleteBatch(ctx context.Context, ids []string) error
     Search(ctx context.Context, vector []float32, k int, filter map[string]any) ([]VectorResult, error)
     Query(ctx context.Context, vector []float32, k int, filter *vecna.Filter) ([]VectorResult, error)
+    Filter(ctx context.Context, filter *vecna.Filter, limit int) ([]VectorResult, error)
     List(ctx context.Context, prefix string, limit int) ([]string, error)
     Exists(ctx context.Context, id string) (bool, error)
 }
@@ -842,6 +859,7 @@ type AtomicIndex interface {
     Exists(ctx context.Context, id string) (bool, error)
     Search(ctx context.Context, vector []float32, k int, filter *atom.Atom) ([]AtomicVector, error)
     Query(ctx context.Context, vector []float32, k int, filter *vecna.Filter) ([]AtomicVector, error)
+    Filter(ctx context.Context, filter *vecna.Filter, limit int) ([]AtomicVector, error)
 }
 ```
 

--- a/docs/5.reference/2.providers.md
+++ b/docs/5.reference/2.providers.md
@@ -469,6 +469,7 @@ All providers map their native errors to grub semantic errors:
 | `ErrTTLNotSupported` | Provider can't handle TTL |
 | `ErrOperatorNotSupported` | Vector provider doesn't support filter operator |
 | `ErrInvalidQuery` | Filter contains validation errors |
+| `ErrFilterNotSupported` | Vector provider doesn't support metadata-only filtering |
 
 ### Context Cancellation
 
@@ -529,6 +530,7 @@ type Config struct {
 | Delete | Points Delete |
 | Search | Points Search |
 | Query | Points Search with Filter |
+| Filter | Points Scroll with Filter |
 | List | Points Scroll |
 
 #### Features
@@ -594,6 +596,7 @@ type Config struct {
 | Delete | Delete |
 | Search | Query with TopK |
 | Query | Query with metadata filter |
+| Filter | Not supported (returns `ErrFilterNotSupported`) |
 | List | ListVectors |
 
 #### Features
@@ -670,6 +673,7 @@ type Config struct {
 | Delete | Delete by ID |
 | Search | Search with expression |
 | Query | Search with translated filter |
+| Filter | Query with expression |
 | List | Query all IDs |
 
 #### Features
@@ -748,6 +752,7 @@ const (
 | Delete | DELETE by ID |
 | Search | SELECT ORDER BY distance |
 | Query | SELECT with JSONB filters |
+| Filter | SELECT with JSONB filters (no vector) |
 | List | SELECT IDs |
 
 #### Features
@@ -816,6 +821,7 @@ type Config struct {
 | Delete | Data Deleter |
 | Search | GraphQL NearVector |
 | Query | GraphQL with Where filter |
+| Filter | GraphQL Get with Where filter |
 | List | GraphQL Get |
 
 #### Features

--- a/index_test.go
+++ b/index_test.go
@@ -20,6 +20,7 @@ type mockVectorProvider struct {
 	deleteErr error
 	searchErr error
 	queryErr  error
+	filterErr error
 	listErr   error
 	existsErr error
 }
@@ -189,6 +190,25 @@ func (m *mockVectorProvider) Exists(_ context.Context, id uuid.UUID) (bool, erro
 	}
 	_, ok := m.vectors[id]
 	return ok, nil
+}
+
+func (m *mockVectorProvider) Filter(_ context.Context, _ *vecna.Filter, limit int) ([]VectorResult, error) {
+	if m.filterErr != nil {
+		return nil, m.filterErr
+	}
+	// For testing, just return all vectors (no filter evaluation).
+	results := make([]VectorResult, 0, len(m.vectors))
+	for id, entry := range m.vectors {
+		results = append(results, VectorResult{
+			ID:       id,
+			Vector:   entry.vector,
+			Metadata: entry.metadata,
+		})
+		if limit > 0 && len(results) >= limit {
+			break
+		}
+	}
+	return results, nil
 }
 
 func matchesFilter(metadata, filter map[string]any) bool {
@@ -474,6 +494,65 @@ func TestIndex_Search(t *testing.T) {
 	})
 }
 
+func TestIndex_Query(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[testMetadata](provider)
+	ctx := context.Background()
+
+	// Setup test vectors
+	id1, id2 := uuid.New(), uuid.New()
+	provider.vectors[id1] = vectorEntry{
+		vector:   []float32{1.0, 0.0},
+		metadata: []byte(`{"category":"a","score":10}`),
+	}
+	provider.vectors[id2] = vectorEntry{
+		vector:   []float32{0.0, 1.0},
+		metadata: []byte(`{"category":"b","score":20}`),
+	}
+
+	t.Run("nil filter", func(t *testing.T) {
+		results, err := index.Query(ctx, []float32{1.0, 0.0}, 10, nil)
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if len(results) != 2 {
+			t.Errorf("expected 2 results, got %d", len(results))
+		}
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		results, err := index.Query(ctx, []float32{1.0, 0.0}, 1, nil)
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Errorf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("metadata decoded", func(t *testing.T) {
+		results, err := index.Query(ctx, []float32{1.0, 0.0}, 10, nil)
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		for _, r := range results {
+			if r.Metadata.Category == "" {
+				t.Error("expected category to be decoded")
+			}
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		provider.queryErr = errors.New("query error")
+		defer func() { provider.queryErr = nil }()
+
+		_, err := index.Query(ctx, []float32{1.0, 0.0}, 1, nil)
+		if err == nil {
+			t.Error("expected provider error")
+		}
+	})
+}
+
 func TestIndex_List(t *testing.T) {
 	provider := newMockVectorProvider()
 	index := NewIndex[testMetadata](provider)
@@ -533,6 +612,133 @@ func TestIndex_Exists(t *testing.T) {
 	})
 }
 
+func TestIndex_Filter(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[testMetadata](provider)
+	ctx := context.Background()
+
+	// Insert test data
+	id1, id2 := uuid.New(), uuid.New()
+	provider.vectors[id1] = vectorEntry{
+		vector:   []float32{1.0, 0.0},
+		metadata: []byte(`{"category":"a","score":10}`),
+	}
+	provider.vectors[id2] = vectorEntry{
+		vector:   []float32{0.0, 1.0},
+		metadata: []byte(`{"category":"b","score":20}`),
+	}
+
+	t.Run("nil filter returns all", func(t *testing.T) {
+		results, err := index.Filter(ctx, nil, 0)
+		if err != nil {
+			t.Fatalf("Filter failed: %v", err)
+		}
+		if len(results) != 2 {
+			t.Errorf("expected 2 results, got %d", len(results))
+		}
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		results, err := index.Filter(ctx, nil, 1)
+		if err != nil {
+			t.Fatalf("Filter failed: %v", err)
+		}
+		if len(results) != 1 {
+			t.Errorf("expected 1 result, got %d", len(results))
+		}
+	})
+
+	t.Run("metadata decoded", func(t *testing.T) {
+		results, err := index.Filter(ctx, nil, 0)
+		if err != nil {
+			t.Fatalf("Filter failed: %v", err)
+		}
+		for _, r := range results {
+			if r.Metadata.Category == "" {
+				t.Error("expected metadata to be decoded")
+			}
+		}
+	})
+}
+
+func TestIndex_FilterProviderError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[testMetadata](provider)
+	ctx := context.Background()
+
+	provider.filterErr = errors.New("filter error")
+	defer func() { provider.filterErr = nil }()
+
+	_, err := index.Filter(ctx, nil, 0)
+	if err == nil {
+		t.Error("expected provider error")
+	}
+}
+
+func TestIndex_NilMetadata(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[testMetadata](provider)
+	ctx := context.Background()
+
+	t.Run("Upsert with nil metadata", func(t *testing.T) {
+		id := uuid.New()
+		err := index.Upsert(ctx, id, []float32{1.0}, nil)
+		if err != nil {
+			t.Fatalf("Upsert failed: %v", err)
+		}
+		// Verify it was stored with nil metadata
+		if provider.vectors[id].metadata != nil {
+			t.Error("expected nil metadata to be stored")
+		}
+	})
+
+	t.Run("Get with nil metadata", func(t *testing.T) {
+		id := uuid.New()
+		provider.vectors[id] = vectorEntry{
+			vector:   []float32{1.0},
+			metadata: nil,
+		}
+		result, err := index.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get failed: %v", err)
+		}
+		// Zero value metadata should be returned
+		if result.Metadata.Category != "" || result.Metadata.Score != 0 {
+			t.Error("expected zero value metadata")
+		}
+	})
+
+	t.Run("Search with nil metadata in results", func(t *testing.T) {
+		id := uuid.New()
+		provider.vectors[id] = vectorEntry{
+			vector:   []float32{1.0, 0.0},
+			metadata: nil,
+		}
+		results, err := index.Search(ctx, []float32{1.0, 0.0}, 10, nil)
+		if err != nil {
+			t.Fatalf("Search failed: %v", err)
+		}
+		if len(results) == 0 {
+			t.Error("expected results")
+		}
+	})
+
+	t.Run("Query with nil metadata in results", func(t *testing.T) {
+		id := uuid.New()
+		provider.vectors[id] = vectorEntry{
+			vector:   []float32{1.0, 0.0},
+			metadata: nil,
+		}
+		results, err := index.Query(ctx, []float32{1.0, 0.0}, 10, nil)
+		if err != nil {
+			t.Fatalf("Query failed: %v", err)
+		}
+		if len(results) == 0 {
+			t.Error("expected results")
+		}
+	})
+}
+
 func TestIndex_RoundTrip(t *testing.T) {
 	provider := newMockVectorProvider()
 	index := NewIndex[testMetadata](provider)
@@ -559,6 +765,113 @@ func TestIndex_RoundTrip(t *testing.T) {
 	}
 	if len(retrieved.Vector) != len(vector) {
 		t.Errorf("Vector length mismatch: got %d, want %d", len(retrieved.Vector), len(vector))
+	}
+}
+
+func TestIndex_DecodeErrors(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[testMetadata](provider)
+	ctx := context.Background()
+
+	// Store invalid JSON that can't be decoded to testMetadata
+	badID := uuid.New()
+	provider.vectors[badID] = vectorEntry{
+		vector:   []float32{1.0, 2.0},
+		metadata: []byte(`{invalid json`),
+	}
+
+	t.Run("Get decode error", func(t *testing.T) {
+		_, err := index.Get(ctx, badID)
+		if err == nil {
+			t.Error("expected decode error")
+		}
+	})
+
+	t.Run("Search decode error", func(t *testing.T) {
+		_, err := index.Search(ctx, []float32{1.0, 2.0}, 10, nil)
+		if err == nil {
+			t.Error("expected decode error")
+		}
+	})
+
+	t.Run("Query decode error", func(t *testing.T) {
+		_, err := index.Query(ctx, []float32{1.0, 2.0}, 10, nil)
+		if err == nil {
+			t.Error("expected decode error")
+		}
+	})
+
+	t.Run("Filter decode error", func(t *testing.T) {
+		_, err := index.Filter(ctx, nil, 0)
+		if err == nil {
+			t.Error("expected decode error")
+		}
+	})
+}
+
+// errorCodec is a codec that can be configured to fail.
+type errorCodec struct {
+	encodeErr error
+	decodeErr error
+}
+
+func (f errorCodec) Encode(v any) ([]byte, error) {
+	if f.encodeErr != nil {
+		return nil, f.encodeErr
+	}
+	return json.Marshal(v)
+}
+
+func (f errorCodec) Decode(data []byte, v any) error {
+	if f.decodeErr != nil {
+		return f.decodeErr
+	}
+	return json.Unmarshal(data, v)
+}
+
+func TestIndex_EncodeErrors(t *testing.T) {
+	provider := newMockVectorProvider()
+	codec := errorCodec{encodeErr: errors.New("encode failed")}
+	index := NewIndexWithCodec[testMetadata](provider, codec)
+	ctx := context.Background()
+
+	t.Run("Upsert encode error", func(t *testing.T) {
+		err := index.Upsert(ctx, uuid.New(), []float32{1.0}, &testMetadata{})
+		if err == nil {
+			t.Error("expected encode error")
+		}
+	})
+
+	t.Run("UpsertBatch encode error", func(t *testing.T) {
+		vectors := []Vector[testMetadata]{
+			{ID: uuid.New(), Vector: []float32{1.0}, Metadata: testMetadata{}},
+		}
+		err := index.UpsertBatch(ctx, vectors)
+		if err == nil {
+			t.Error("expected encode error")
+		}
+	})
+
+	t.Run("Search encodeFilter error", func(t *testing.T) {
+		filter := &testMetadata{Category: "test"}
+		_, err := index.Search(ctx, []float32{1.0}, 10, filter)
+		if err == nil {
+			t.Error("expected encode error")
+		}
+	})
+}
+
+func TestIndex_EncodeFilterDecodeError(t *testing.T) {
+	provider := newMockVectorProvider()
+	// Codec that encodes fine but fails on decode (for encodeFilter's second step)
+	codec := errorCodec{decodeErr: errors.New("decode failed")}
+	index := NewIndexWithCodec[testMetadata](provider, codec)
+	ctx := context.Background()
+
+	filter := &testMetadata{Category: "test"}
+	_, err := index.Search(ctx, []float32{1.0}, 10, filter)
+	if err == nil {
+		t.Error("expected decode error in encodeFilter")
 	}
 }
 

--- a/internal/shared/errors.go
+++ b/internal/shared/errors.go
@@ -46,4 +46,7 @@ var (
 
 	// ErrOperatorNotSupported indicates the filter operator is not supported by the provider.
 	ErrOperatorNotSupported = errors.New("grub: operator not supported by provider")
+
+	// ErrFilterNotSupported indicates the provider does not support metadata-only filtering.
+	ErrFilterNotSupported = errors.New("grub: filter not supported by provider")
 )

--- a/pinecone/provider.go
+++ b/pinecone/provider.go
@@ -211,6 +211,11 @@ func (p *Provider) Query(ctx context.Context, vector []float32, k int, filter *v
 	return results, nil
 }
 
+// Filter returns ErrFilterNotSupported as Pinecone does not support metadata-only filtering.
+func (p *Provider) Filter(_ context.Context, _ *vecna.Filter, _ int) ([]grub.VectorResult, error) {
+	return nil, grub.ErrFilterNotSupported
+}
+
 // List returns vector IDs.
 func (p *Provider) List(ctx context.Context, limit int) ([]uuid.UUID, error) {
 	req := &pinecone.ListVectorsRequest{}

--- a/testing/integration/vector/milvus/milvus_test.go
+++ b/testing/integration/vector/milvus/milvus_test.go
@@ -152,3 +152,7 @@ func TestMilvus_Query(t *testing.T) {
 		Contains: true,
 	})
 }
+
+func TestMilvus_Filter(t *testing.T) {
+	vector.RunFilterTests(t, tc, true)
+}

--- a/testing/integration/vector/pgvector/pgvector_test.go
+++ b/testing/integration/vector/pgvector/pgvector_test.go
@@ -119,3 +119,7 @@ func TestPgvector_Query(t *testing.T) {
 		Contains: true,
 	})
 }
+
+func TestPgvector_Filter(t *testing.T) {
+	vector.RunFilterTests(t, tc, true)
+}

--- a/testing/integration/vector/pinecone/pinecone_test.go
+++ b/testing/integration/vector/pinecone/pinecone_test.go
@@ -126,3 +126,8 @@ func TestPinecone_Query(t *testing.T) {
 		Contains: false,
 	})
 }
+
+func TestPinecone_Filter(t *testing.T) {
+	// Pinecone doesn't support metadata-only filtering
+	vector.RunFilterTests(t, tc, false)
+}

--- a/testing/integration/vector/qdrant/qdrant_test.go
+++ b/testing/integration/vector/qdrant/qdrant_test.go
@@ -117,3 +117,7 @@ func TestQdrant_Query(t *testing.T) {
 		Contains: true,
 	})
 }
+
+func TestQdrant_Filter(t *testing.T) {
+	vector.RunFilterTests(t, tc, true)
+}

--- a/testing/integration/vector/weaviate/weaviate_test.go
+++ b/testing/integration/vector/weaviate/weaviate_test.go
@@ -143,3 +143,7 @@ func TestWeaviate_Query(t *testing.T) {
 		Contains: true,
 	})
 }
+
+func TestWeaviate_Filter(t *testing.T) {
+	vector.RunFilterTests(t, tc, true)
+}


### PR DESCRIPTION
  Add Filter(ctx, filter, limit) method to query vectors by metadata
  without similarity search. Supports all providers except Pinecone
  (returns ErrFilterNotSupported).

  - Add ErrFilterNotSupported error
  - Add Filter to VectorProvider and AtomicIndex interfaces
  - Implement for pgvector (native SQL), Qdrant (Scroll API), Weaviate (GraphQL Get), Milvus (Query API)
  - Pinecone returns ErrFilterNotSupported (no native support)
  - Add integration tests for all providers
  - Add unit test for Index[T].Filter
  - Update API and provider reference documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata-only filtering: new Filter APIs to retrieve vectors by metadata (no similarity search); limit=0 returns all matches. A public "filter not supported" error is returned by providers that lack this capability.

* **Documentation**
  * API and provider docs updated with filter semantics, provider-specific behavior, ordering notes, and error handling.

* **Tests**
  * Expanded unit and integration tests covering filter flows, limits, nil metadata, and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->