### PR TITLE
feat!: surface soy query builders on Database[T]

### DIFF
--- a/api.go
+++ b/api.go
@@ -111,11 +111,11 @@ type AtomicDatabase interface {
 	// Exists checks whether a record exists at key.
 	Exists(ctx context.Context, key string) (bool, error)
 
-	// Query executes a query statement and returns atoms.
-	Query(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*atom.Atom, error)
+	// ExecQuery executes a query statement and returns atoms.
+	ExecQuery(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*atom.Atom, error)
 
-	// Select executes a select statement and returns an atom.
-	Select(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*atom.Atom, error)
+	// ExecSelect executes a select statement and returns an atom.
+	ExecSelect(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*atom.Atom, error)
 }
 
 // BucketProvider defines raw blob storage operations.

--- a/database.go
+++ b/database.go
@@ -111,23 +111,53 @@ func (d *Database[T]) Executor() *edamame.Executor[T] {
 	return d.executor
 }
 
-// Query executes a query statement and returns multiple records.
-func (d *Database[T]) Query(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*T, error) {
+// Query returns a query builder for fetching multiple records.
+func (d *Database[T]) Query() *soy.Query[T] {
+	return d.executor.Soy().Query()
+}
+
+// Select returns a select builder for fetching a single record.
+func (d *Database[T]) Select() *soy.Select[T] {
+	return d.executor.Soy().Select()
+}
+
+// Insert returns an insert builder (auto-generates PK).
+func (d *Database[T]) Insert() *soy.Create[T] {
+	return d.executor.Soy().Insert()
+}
+
+// InsertFull returns an insert builder that includes the PK field.
+func (d *Database[T]) InsertFull() *soy.Create[T] {
+	return d.executor.Soy().InsertFull()
+}
+
+// Modify returns an update builder.
+func (d *Database[T]) Modify() *soy.Update[T] {
+	return d.executor.Soy().Modify()
+}
+
+// Remove returns a delete builder.
+func (d *Database[T]) Remove() *soy.Delete[T] {
+	return d.executor.Soy().Remove()
+}
+
+// ExecQuery executes a query statement and returns multiple records.
+func (d *Database[T]) ExecQuery(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*T, error) {
 	return d.executor.ExecQuery(ctx, stmt, params)
 }
 
-// Select executes a select statement and returns a single record.
-func (d *Database[T]) Select(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*T, error) {
+// ExecSelect executes a select statement and returns a single record.
+func (d *Database[T]) ExecSelect(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*T, error) {
 	return d.executor.ExecSelect(ctx, stmt, params)
 }
 
-// Update executes an update statement.
-func (d *Database[T]) Update(ctx context.Context, stmt edamame.UpdateStatement, params map[string]any) (*T, error) {
+// ExecUpdate executes an update statement.
+func (d *Database[T]) ExecUpdate(ctx context.Context, stmt edamame.UpdateStatement, params map[string]any) (*T, error) {
 	return d.executor.ExecUpdate(ctx, stmt, params)
 }
 
-// Aggregate executes an aggregate statement.
-func (d *Database[T]) Aggregate(ctx context.Context, stmt edamame.AggregateStatement, params map[string]any) (float64, error) {
+// ExecAggregate executes an aggregate statement.
+func (d *Database[T]) ExecAggregate(ctx context.Context, stmt edamame.AggregateStatement, params map[string]any) (float64, error) {
 	return d.executor.ExecAggregate(ctx, stmt, params)
 }
 
@@ -189,23 +219,23 @@ func (d *Database[T]) ExistsTx(ctx context.Context, tx *sqlx.Tx, key string) (bo
 	return len(results) > 0, nil
 }
 
-// QueryTx executes a query statement within a transaction and returns multiple records.
-func (d *Database[T]) QueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.QueryStatement, params map[string]any) ([]*T, error) {
+// ExecQueryTx executes a query statement within a transaction and returns multiple records.
+func (d *Database[T]) ExecQueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.QueryStatement, params map[string]any) ([]*T, error) {
 	return d.executor.ExecQueryTx(ctx, tx, stmt, params)
 }
 
-// SelectTx executes a select statement within a transaction and returns a single record.
-func (d *Database[T]) SelectTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.SelectStatement, params map[string]any) (*T, error) {
+// ExecSelectTx executes a select statement within a transaction and returns a single record.
+func (d *Database[T]) ExecSelectTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.SelectStatement, params map[string]any) (*T, error) {
 	return d.executor.ExecSelectTx(ctx, tx, stmt, params)
 }
 
-// UpdateTx executes an update statement within a transaction.
-func (d *Database[T]) UpdateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.UpdateStatement, params map[string]any) (*T, error) {
+// ExecUpdateTx executes an update statement within a transaction.
+func (d *Database[T]) ExecUpdateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.UpdateStatement, params map[string]any) (*T, error) {
 	return d.executor.ExecUpdateTx(ctx, tx, stmt, params)
 }
 
-// AggregateTx executes an aggregate statement within a transaction.
-func (d *Database[T]) AggregateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.AggregateStatement, params map[string]any) (float64, error) {
+// ExecAggregateTx executes an aggregate statement within a transaction.
+func (d *Database[T]) ExecAggregateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.AggregateStatement, params map[string]any) (float64, error) {
 	return d.executor.ExecAggregateTx(ctx, tx, stmt, params)
 }
 

--- a/docs/1.overview.md
+++ b/docs/1.overview.md
@@ -107,7 +107,7 @@ db, _ := grub.NewDatabase[User](sqlxDB, "users", "id", sqlite.New())
 
 db.Set(ctx, "1", &User{ID: 1, Email: "alice@example.com"})
 user, _ := db.Get(ctx, "1")
-users, _ := db.Query(ctx, "active", nil)
+users, _ := db.Query().Where("status", "=", "active").Exec(ctx, map[string]any{"active": "enabled"})
 ```
 
 **Drivers:** PostgreSQL, MariaDB, SQLite, SQL Server

--- a/docs/2.learn/2.concepts.md
+++ b/docs/2.learn/2.concepts.md
@@ -158,9 +158,12 @@ err = db.Set(ctx, "123", &User{ID: "123", Name: "Alice"})
 err = db.Delete(ctx, "123")
 exists, err := db.Exists(ctx, "123")
 
-// Named queries (defined via edamame)
-users, err := db.Query(ctx, "active", nil)
-user, err := db.Select(ctx, "by_email", map[string]any{"email": "alice@example.com"})
+// Query builders for ad-hoc queries
+users, err := db.Query().Where("status", "=", "active").Exec(ctx, map[string]any{"active": "enabled"})
+user, err := db.Select().Where("email", "=", "email").Exec(ctx, map[string]any{"email": "alice@example.com"})
+
+// Pre-defined statements via edamame
+users, err := db.ExecQuery(ctx, grub.QueryAll, nil)
 ```
 
 ### Set Behavior

--- a/docs/3.guides/2.lifecycle.md
+++ b/docs/3.guides/2.lifecycle.md
@@ -236,42 +236,53 @@ Checks if a record exists.
 exists, err := db.Exists(ctx, "123")
 ```
 
-### Query
+### Query Builder
 
-Executes a named query returning multiple records.
+Returns a query builder for fetching multiple records.
 
 ```go
-// Query defined in edamame factory
-users, err := db.Query(ctx, "active", nil)
+// Using the query builder
+users, err := db.Query().
+    Where("status", "=", "active").
+    Exec(ctx, map[string]any{"active": "enabled"})
 
 // With parameters
-users, err := db.Query(ctx, "by_role", map[string]any{"role": "admin"})
+users, err := db.Query().
+    Where("role", "=", "role").
+    Exec(ctx, map[string]any{"role": "admin"})
 ```
 
-### Select
+### Select Builder
 
-Executes a named query returning a single record.
+Returns a select builder for fetching a single record.
 
 ```go
-user, err := db.Select(ctx, "by_email", map[string]any{
-    "email": "alice@example.com",
-})
+user, err := db.Select().
+    Where("email", "=", "email").
+    Exec(ctx, map[string]any{"email": "alice@example.com"})
 ```
 
-### Update
+### Modify Builder
 
-Executes a named update returning the modified record.
+Returns an update builder for modifying records.
 
 ```go
-user, err := db.Update(ctx, "deactivate", map[string]any{"id": "123"})
+user, err := db.Modify().
+    Set("status", "new_status").
+    Where("id", "=", "user_id").
+    Exec(ctx, map[string]any{"new_status": "inactive", "user_id": "123"})
 ```
 
-### Aggregate
+### Statement Execution
 
-Executes a named aggregate query.
+Execute pre-defined edamame statements.
 
 ```go
-count, err := db.Aggregate(ctx, "count_active", nil)
+// Query all records
+users, err := db.ExecQuery(ctx, grub.QueryAll, nil)
+
+// Count records
+count, err := db.ExecAggregate(ctx, grub.CountAll, nil)
 ```
 
 ## Common Patterns

--- a/docs/3.guides/3.pagination.md
+++ b/docs/3.guides/3.pagination.md
@@ -140,13 +140,30 @@ func ListAllObjects(ctx context.Context, bucket *grub.Bucket[Doc], prefix string
 
 ## Database Query Pagination
 
-For SQL databases, use query parameters:
+For SQL databases, use query builders or pre-defined statements.
 
-### Offset-Based Pagination
+### Using Query Builder
 
 ```go
-// Define query in edamame factory with LIMIT/OFFSET
-users, err := db.Query(ctx, "paginated", map[string]any{
+// Offset-based pagination with builder
+users, err := db.Query().
+    OrderBy("created_at", "DESC").
+    Limit(20).
+    Offset(40). // Page 3
+    Exec(ctx, nil)
+```
+
+### Using Pre-defined Statements
+
+```go
+// Define statement with LIMIT/OFFSET params
+paginatedStmt := edamame.NewQueryStatement("paginated", "Paginated users", edamame.QuerySpec{
+    OrderBy:     []edamame.OrderBySpec{{Field: "created_at", Direction: "desc"}},
+    LimitParam:  "limit",
+    OffsetParam: "offset",
+})
+
+users, err := db.ExecQuery(ctx, paginatedStmt, map[string]any{
     "limit":  20,
     "offset": 40, // Page 3
 })
@@ -157,11 +174,12 @@ users, err := db.Query(ctx, "paginated", map[string]any{
 More efficient for large datasets:
 
 ```go
-// Define query with WHERE id > :cursor
-users, err := db.Query(ctx, "after_cursor", map[string]any{
-    "cursor": lastID,
-    "limit":  20,
-})
+// Using builder
+users, err := db.Query().
+    Where("id", ">", "cursor").
+    OrderBy("id", "ASC").
+    Limit(20).
+    Exec(ctx, map[string]any{"cursor": lastID})
 ```
 
 ## Performance Considerations

--- a/docs/4.cookbook/2.migrations.md
+++ b/docs/4.cookbook/2.migrations.md
@@ -398,8 +398,8 @@ prodDB, _ := grub.NewDatabase[User](pgConn, "users", "id", postgres.New())
 ### Data Export/Import
 
 ```go
-func ExportTable[T any](ctx context.Context, db *grub.Database[T], query string) ([]*T, error) {
-    return db.Query(ctx, query, nil)
+func ExportTable[T any](ctx context.Context, db *grub.Database[T]) ([]*T, error) {
+    return db.ExecQuery(ctx, grub.QueryAll, nil)
 }
 
 func ImportTable[T any](ctx context.Context, db *grub.Database[T], records []*T, keyFn func(*T) string) error {

--- a/docs/4.cookbook/3.multi-tenant.md
+++ b/docs/4.cookbook/3.multi-tenant.md
@@ -378,10 +378,10 @@ type TenantUser struct {
     Email    string `json:"email" db:"email"`
 }
 
-// Query with tenant filter
-users, _ := db.Query(ctx, "by_tenant", map[string]any{
-    "tenant_id": tenantID,
-})
+// Query with tenant filter using builder
+users, _ := db.Query().
+    Where("tenant_id", "=", "tenant_id").
+    Exec(ctx, map[string]any{"tenant_id": tenantID})
 ```
 
 ### Schema-Level Isolation (PostgreSQL)

--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -349,49 +349,140 @@ func (d *Database[T]) Exists(ctx context.Context, key string) (bool, error)
 
 Checks if record exists.
 
+### Query Builders
+
+Direct access to soy query builders for ad-hoc queries.
+
 #### Query
 
 ```go
-func (d *Database[T]) Query(ctx context.Context, name string, params map[string]any) ([]*T, error)
+func (d *Database[T]) Query() *soy.Query[T]
 ```
 
-Executes named query returning multiple records.
+Returns a query builder for fetching multiple records.
 
 ```go
-users, err := db.Query(ctx, "active", nil)
-users, err := db.Query(ctx, "by_role", map[string]any{"role": "admin"})
+users, err := db.Query().
+    Where("age", ">=", "min_age").
+    OrderBy("name", "ASC").
+    Limit(10).
+    Exec(ctx, map[string]any{"min_age": 18})
 ```
 
 #### Select
 
 ```go
-func (d *Database[T]) Select(ctx context.Context, name string, params map[string]any) (*T, error)
+func (d *Database[T]) Select() *soy.Select[T]
 ```
 
-Executes named query returning single record.
+Returns a select builder for fetching a single record.
 
 ```go
-user, err := db.Select(ctx, "by_email", map[string]any{"email": "alice@example.com"})
+user, err := db.Select().
+    Where("email", "=", "email").
+    Exec(ctx, map[string]any{"email": "alice@example.com"})
 ```
 
-#### Update
+#### Insert
 
 ```go
-func (d *Database[T]) Update(ctx context.Context, name string, params map[string]any) (*T, error)
+func (d *Database[T]) Insert() *soy.Create[T]
 ```
 
-Executes named update returning modified record.
-
-#### Aggregate
+Returns an insert builder (auto-generates PK).
 
 ```go
-func (d *Database[T]) Aggregate(ctx context.Context, stmt edamame.AggregateStatement, params map[string]any) (float64, error)
+user, err := db.Insert().Exec(ctx, &User{Name: "Alice", Email: "alice@example.com"})
+```
+
+#### InsertFull
+
+```go
+func (d *Database[T]) InsertFull() *soy.Create[T]
+```
+
+Returns an insert builder that includes the PK field.
+
+```go
+user, err := db.InsertFull().Exec(ctx, &User{ID: 123, Name: "Alice"})
+```
+
+#### Modify
+
+```go
+func (d *Database[T]) Modify() *soy.Update[T]
+```
+
+Returns an update builder.
+
+```go
+updated, err := db.Modify().
+    Set("name", "new_name").
+    Where("id", "=", "user_id").
+    Exec(ctx, map[string]any{"new_name": "Bob", "user_id": 123})
+```
+
+#### Remove
+
+```go
+func (d *Database[T]) Remove() *soy.Delete[T]
+```
+
+Returns a delete builder.
+
+```go
+affected, err := db.Remove().
+    Where("status", "=", "inactive").
+    Exec(ctx, map[string]any{"inactive": "deleted"})
+```
+
+### Statement Execution
+
+Execute pre-defined edamame statements.
+
+#### ExecQuery
+
+```go
+func (d *Database[T]) ExecQuery(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*T, error)
+```
+
+Executes a query statement returning multiple records.
+
+```go
+users, err := db.ExecQuery(ctx, grub.QueryAll, nil)
+users, err := db.ExecQuery(ctx, byRoleStmt, map[string]any{"role": "admin"})
+```
+
+#### ExecSelect
+
+```go
+func (d *Database[T]) ExecSelect(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*T, error)
+```
+
+Executes a select statement returning a single record.
+
+```go
+user, err := db.ExecSelect(ctx, byEmailStmt, map[string]any{"email": "alice@example.com"})
+```
+
+#### ExecUpdate
+
+```go
+func (d *Database[T]) ExecUpdate(ctx context.Context, stmt edamame.UpdateStatement, params map[string]any) (*T, error)
+```
+
+Executes an update statement returning the modified record.
+
+#### ExecAggregate
+
+```go
+func (d *Database[T]) ExecAggregate(ctx context.Context, stmt edamame.AggregateStatement, params map[string]any) (float64, error)
 ```
 
 Executes an aggregate statement.
 
 ```go
-count, err := db.Aggregate(ctx, grub.CountAll, nil)
+count, err := db.ExecAggregate(ctx, grub.CountAll, nil)
 ```
 
 ### Transaction Methods
@@ -422,28 +513,28 @@ func (d *Database[T]) DeleteTx(ctx context.Context, tx *sqlx.Tx, key string) err
 func (d *Database[T]) ExistsTx(ctx context.Context, tx *sqlx.Tx, key string) (bool, error)
 ```
 
-#### QueryTx
+#### ExecQueryTx
 
 ```go
-func (d *Database[T]) QueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.QueryStatement, params map[string]any) ([]*T, error)
+func (d *Database[T]) ExecQueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.QueryStatement, params map[string]any) ([]*T, error)
 ```
 
-#### SelectTx
+#### ExecSelectTx
 
 ```go
-func (d *Database[T]) SelectTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.SelectStatement, params map[string]any) (*T, error)
+func (d *Database[T]) ExecSelectTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.SelectStatement, params map[string]any) (*T, error)
 ```
 
-#### UpdateTx
+#### ExecUpdateTx
 
 ```go
-func (d *Database[T]) UpdateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.UpdateStatement, params map[string]any) (*T, error)
+func (d *Database[T]) ExecUpdateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.UpdateStatement, params map[string]any) (*T, error)
 ```
 
-#### AggregateTx
+#### ExecAggregateTx
 
 ```go
-func (d *Database[T]) AggregateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.AggregateStatement, params map[string]any) (float64, error)
+func (d *Database[T]) ExecAggregateTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.AggregateStatement, params map[string]any) (float64, error)
 ```
 
 #### Usage Example
@@ -841,8 +932,8 @@ type AtomicDatabase interface {
     Set(ctx context.Context, key string, a *atom.Atom) error
     Delete(ctx context.Context, key string) error
     Exists(ctx context.Context, key string) (bool, error)
-    Query(ctx context.Context, name string, params map[string]any) ([]*atom.Atom, error)
-    Select(ctx context.Context, name string, params map[string]any) (*atom.Atom, error)
+    ExecQuery(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*atom.Atom, error)
+    ExecSelect(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*atom.Atom, error)
 }
 ```
 

--- a/internal/atomic/database.go
+++ b/internal/atomic/database.go
@@ -108,13 +108,13 @@ func (d *Database[T]) Exists(ctx context.Context, key string) (bool, error) {
 	return len(results) > 0, nil
 }
 
-// Query executes a query statement and returns atoms.
-func (d *Database[T]) Query(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*atom.Atom, error) {
+// ExecQuery executes a query statement and returns atoms.
+func (d *Database[T]) ExecQuery(ctx context.Context, stmt edamame.QueryStatement, params map[string]any) ([]*atom.Atom, error) {
 	return d.executor.ExecQueryAtom(ctx, stmt, params)
 }
 
-// Select executes a select statement and returns an atom.
-func (d *Database[T]) Select(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*atom.Atom, error) {
+// ExecSelect executes a select statement and returns an atom.
+func (d *Database[T]) ExecSelect(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) (*atom.Atom, error) {
 	return d.executor.ExecSelectAtom(ctx, stmt, params)
 }
 
@@ -185,8 +185,8 @@ func (d *Database[T]) ExistsTx(ctx context.Context, tx *sqlx.Tx, key string) (bo
 	return len(results) > 0, nil
 }
 
-// QueryTx executes a query statement within a transaction and returns atoms.
-func (d *Database[T]) QueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.QueryStatement, params map[string]any) ([]*atom.Atom, error) {
+// ExecQueryTx executes a query statement within a transaction and returns atoms.
+func (d *Database[T]) ExecQueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.QueryStatement, params map[string]any) ([]*atom.Atom, error) {
 	q, err := d.executor.Query(stmt)
 	if err != nil {
 		return nil, err
@@ -194,8 +194,8 @@ func (d *Database[T]) QueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.Que
 	return q.ExecTxAtom(ctx, tx, params)
 }
 
-// SelectTx executes a select statement within a transaction and returns an atom.
-func (d *Database[T]) SelectTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.SelectStatement, params map[string]any) (*atom.Atom, error) {
+// ExecSelectTx executes a select statement within a transaction and returns an atom.
+func (d *Database[T]) ExecSelectTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.SelectStatement, params map[string]any) (*atom.Atom, error) {
 	s, err := d.executor.Select(stmt)
 	if err != nil {
 		return nil, err

--- a/internal/atomic/database_test.go
+++ b/internal/atomic/database_test.go
@@ -224,7 +224,7 @@ func TestDatabase_Exists(t *testing.T) {
 	}
 }
 
-func TestDatabase_Query(t *testing.T) {
+func TestDatabase_ExecQuery(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	executor, err := edamame.New[TestUser](mockDB, "test_users", testRenderer)
 	if err != nil {
@@ -238,7 +238,7 @@ func TestDatabase_Query(t *testing.T) {
 	ctx := context.Background()
 
 	stmt := edamame.NewQueryStatement("query", "Query all", edamame.QuerySpec{})
-	_, _ = db.Query(ctx, stmt, nil)
+	_, _ = db.ExecQuery(ctx, stmt, nil)
 
 	query, ok := capture.Last()
 	if !ok {
@@ -253,7 +253,7 @@ func TestDatabase_Query(t *testing.T) {
 	}
 }
 
-func TestDatabase_Select(t *testing.T) {
+func TestDatabase_ExecSelect(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	executor, err := edamame.New[TestUser](mockDB, "test_users", testRenderer)
 	if err != nil {
@@ -272,7 +272,7 @@ func TestDatabase_Select(t *testing.T) {
 		},
 	})
 
-	_, _ = db.Select(ctx, stmt, map[string]any{"email": "test@example.com"})
+	_, _ = db.ExecSelect(ctx, stmt, map[string]any{"email": "test@example.com"})
 
 	query, ok := capture.Last()
 	if !ok {
@@ -562,7 +562,7 @@ func TestDatabase_ExistsTx(t *testing.T) {
 	}
 }
 
-func TestDatabase_QueryTx(t *testing.T) {
+func TestDatabase_ExecQueryTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	executor, err := edamame.New[TestUser](mockDB, "test_users", testRenderer)
 	if err != nil {
@@ -582,7 +582,7 @@ func TestDatabase_QueryTx(t *testing.T) {
 	defer tx.Rollback()
 
 	stmt := edamame.NewQueryStatement("query", "Query all", edamame.QuerySpec{})
-	_, _ = db.QueryTx(ctx, tx, stmt, nil)
+	_, _ = db.ExecQueryTx(ctx, tx, stmt, nil)
 
 	query, ok := capture.Last()
 	if !ok {
@@ -597,7 +597,7 @@ func TestDatabase_QueryTx(t *testing.T) {
 	}
 }
 
-func TestDatabase_SelectTx(t *testing.T) {
+func TestDatabase_ExecSelectTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	executor, err := edamame.New[TestUser](mockDB, "test_users", testRenderer)
 	if err != nil {
@@ -622,7 +622,7 @@ func TestDatabase_SelectTx(t *testing.T) {
 		},
 	})
 
-	_, _ = db.SelectTx(ctx, tx, stmt, map[string]any{"email": "test@example.com"})
+	_, _ = db.ExecSelectTx(ctx, tx, stmt, map[string]any{"email": "test@example.com"})
 
 	query, ok := capture.Last()
 	if !ok {
@@ -792,7 +792,7 @@ func TestDatabase_ExistsTx_QueryError(t *testing.T) {
 	}
 }
 
-func TestDatabase_QueryTx_StatementError(t *testing.T) {
+func TestDatabase_ExecQueryTx_StatementError(t *testing.T) {
 	mockDB, _ := mockdb.New()
 	executor, err := edamame.New[TestUser](mockDB, "test_users", testRenderer)
 	if err != nil {
@@ -818,13 +818,13 @@ func TestDatabase_QueryTx_StatementError(t *testing.T) {
 		},
 	})
 
-	_, err = db.QueryTx(ctx, tx, invalidStmt, map[string]any{"value": "test"})
+	_, err = db.ExecQueryTx(ctx, tx, invalidStmt, map[string]any{"value": "test"})
 	if err == nil {
 		t.Error("expected error for invalid statement field")
 	}
 }
 
-func TestDatabase_SelectTx_StatementError(t *testing.T) {
+func TestDatabase_ExecSelectTx_StatementError(t *testing.T) {
 	mockDB, _ := mockdb.New()
 	executor, err := edamame.New[TestUser](mockDB, "test_users", testRenderer)
 	if err != nil {
@@ -850,7 +850,7 @@ func TestDatabase_SelectTx_StatementError(t *testing.T) {
 		},
 	})
 
-	_, err = db.SelectTx(ctx, tx, invalidStmt, map[string]any{"value": "test"})
+	_, err = db.ExecSelectTx(ctx, tx, invalidStmt, map[string]any{"value": "test"})
 	if err == nil {
 		t.Error("expected error for invalid statement field")
 	}

--- a/testing/integration/database/shared.go
+++ b/testing/integration/database/shared.go
@@ -323,7 +323,7 @@ func testQuery(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to create database: %v", err)
 	}
 
-	users, err := db.Query(ctx, grub.QueryAll, nil)
+	users, err := db.ExecQuery(ctx, grub.QueryAll, nil)
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -361,7 +361,7 @@ func testQueryWithStatement(t *testing.T, tc *TestContext) {
 		},
 	})
 
-	users, err := db.Query(ctx, stmt, map[string]any{"min_age": 30})
+	users, err := db.ExecQuery(ctx, stmt, map[string]any{"min_age": 30})
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
 	}
@@ -393,7 +393,7 @@ func testQueryAtom(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to create database: %v", err)
 	}
 
-	atoms, err := db.Atomic().Query(ctx, grub.QueryAll, nil)
+	atoms, err := db.Atomic().ExecQuery(ctx, grub.QueryAll, nil)
 	if err != nil {
 		t.Fatalf("Atomic().Query failed: %v", err)
 	}
@@ -435,7 +435,7 @@ func testSelect(t *testing.T, tc *TestContext) {
 		},
 	})
 
-	user, err := db.Select(ctx, stmt, map[string]any{"email": "bob@example.com"})
+	user, err := db.ExecSelect(ctx, stmt, map[string]any{"email": "bob@example.com"})
 	if err != nil {
 		t.Fatalf("Select failed: %v", err)
 	}
@@ -468,7 +468,7 @@ func testSelectAtom(t *testing.T, tc *TestContext) {
 		},
 	})
 
-	a, err := db.Atomic().Select(ctx, stmt, map[string]any{"name": "Carol"})
+	a, err := db.Atomic().ExecSelect(ctx, stmt, map[string]any{"name": "Carol"})
 	if err != nil {
 		t.Fatalf("Atomic().Select failed: %v", err)
 	}
@@ -504,7 +504,7 @@ func testUpdate(t *testing.T, tc *TestContext) {
 		},
 	})
 
-	updated, err := db.Update(ctx, stmt, map[string]any{
+	updated, err := db.ExecUpdate(ctx, stmt, map[string]any{
 		"email":    "update@example.com",
 		"new_name": "Updated",
 	})
@@ -544,7 +544,7 @@ func testAggregate(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to create database: %v", err)
 	}
 
-	count, err := db.Aggregate(ctx, grub.CountAll, nil)
+	count, err := db.ExecAggregate(ctx, grub.CountAll, nil)
 	if err != nil {
 		t.Fatalf("Aggregate failed: %v", err)
 	}
@@ -577,7 +577,7 @@ func testAggregateSum(t *testing.T, tc *TestContext) {
 		Field: "age",
 	})
 
-	sum, err := db.Aggregate(ctx, stmt, nil)
+	sum, err := db.ExecAggregate(ctx, stmt, nil)
 	if err != nil {
 		t.Fatalf("Aggregate failed: %v", err)
 	}
@@ -616,7 +616,7 @@ func testQueryPagination(t *testing.T, tc *TestContext) {
 		OffsetParam: "offset",
 	})
 
-	page1, err := db.Query(ctx, stmt, map[string]any{"limit": 2, "offset": 0})
+	page1, err := db.ExecQuery(ctx, stmt, map[string]any{"limit": 2, "offset": 0})
 	if err != nil {
 		t.Fatalf("Query page 1 failed: %v", err)
 	}
@@ -627,7 +627,7 @@ func testQueryPagination(t *testing.T, tc *TestContext) {
 		t.Errorf("expected first user Alice, got %s", page1[0].Name)
 	}
 
-	page2, err := db.Query(ctx, stmt, map[string]any{"limit": 2, "offset": 2})
+	page2, err := db.ExecQuery(ctx, stmt, map[string]any{"limit": 2, "offset": 2})
 	if err != nil {
 		t.Fatalf("Query page 2 failed: %v", err)
 	}
@@ -866,7 +866,7 @@ func testQueryTx(t *testing.T, tc *TestContext) {
 	}
 	defer tx.Rollback()
 
-	users, err := db.QueryTx(ctx, tx, grub.QueryAll, nil)
+	users, err := db.ExecQueryTx(ctx, tx, grub.QueryAll, nil)
 	if err != nil {
 		t.Fatalf("QueryTx failed: %v", err)
 	}
@@ -904,7 +904,7 @@ func testUpdateTx(t *testing.T, tc *TestContext) {
 		},
 	})
 
-	updated, err := db.UpdateTx(ctx, tx, stmt, map[string]any{
+	updated, err := db.ExecUpdateTx(ctx, tx, stmt, map[string]any{
 		"email":    "update@example.com",
 		"new_name": "TxUpdated",
 	})
@@ -953,7 +953,7 @@ func testAggregateTx(t *testing.T, tc *TestContext) {
 	}
 	defer tx.Rollback()
 
-	count, err := db.AggregateTx(ctx, tx, grub.CountAll, nil)
+	count, err := db.ExecAggregateTx(ctx, tx, grub.CountAll, nil)
 	if err != nil {
 		t.Fatalf("AggregateTx failed: %v", err)
 	}


### PR DESCRIPTION
  BREAKING CHANGE: Statement execution methods renamed with Exec prefix.
  - Query → ExecQuery
  - Select → ExecSelect
  - Update → ExecUpdate
  - Aggregate → ExecAggregate
  - QueryTx → ExecQueryTx
  - SelectTx → ExecSelectTx
  - UpdateTx → ExecUpdateTx
  - AggregateTx → ExecAggregateTx

  New builder accessors provide direct access to soy query builders:
  - Query() → *soy.Query[T]
  - Select() → *soy.Select[T]
  - Insert() → *soy.Create[T]
  - InsertFull() → *soy.Create[T]
  - Modify() → *soy.Update[T]
  - Remove() → *soy.Delete[T]

  Before:
    db.Executor().Soy().Select().Where(...).Exec(ctx, params)

  After:
    db.Select().Where(...).Exec(ctx, params)

  The AtomicDatabase interface updated to match (Query/Select → ExecQuery/ExecSelect).

  Migration: Add "Exec" prefix to existing Query/Select/Update/Aggregate calls.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Public DB and AtomicDatabase methods renamed to Exec-prefixed variants (e.g., Query→ExecQuery, Select→ExecSelect) including transaction variants.

* **New Features**
  * Added builder-style APIs for queries and mutations (Query(), Select(), Insert(), InsertFull(), Modify(), Remove()) plus Exec* execution methods for statements.

* **Documentation**
  * Guides, examples, and cookbooks updated to show builder + Exec-based workflows.

* **Tests**
  * Test suite updated to exercise builders and Exec-prefixed methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->