### PR TITLE
fix: remove redundant pk arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Swap Redis for BadgerDB. Move from S3 to Azure. Switch databases from SQLite to 
 // Key-value, blob, SQL, or vector — same patterns
 store := grub.NewStore[Config](provider)           // key-value
 bucket := grub.NewBucket[Document](provider)       // blob storage
-db, _ := grub.NewDatabase[User](conn, "users", "id", renderer)  // SQL
+db, _ := grub.NewDatabase[User](conn, "users", renderer)        // SQL
 index := grub.NewIndex[Embedding](provider)        // vector search
 ```
 

--- a/api.go
+++ b/api.go
@@ -31,6 +31,8 @@ var (
 	ErrInvalidQuery         = shared.ErrInvalidQuery
 	ErrOperatorNotSupported = shared.ErrOperatorNotSupported
 	ErrFilterNotSupported   = shared.ErrFilterNotSupported
+	ErrNoPrimaryKey         = shared.ErrNoPrimaryKey
+	ErrMultiplePrimaryKeys  = shared.ErrMultiplePrimaryKeys
 )
 
 // StoreProvider defines raw key-value storage operations.

--- a/database_test.go
+++ b/database_test.go
@@ -30,7 +30,7 @@ var testDBRenderer = astqlsqlite.New()
 
 func TestNewDatabase(t *testing.T) {
 	mockDB, _ := mockdb.New()
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestDatabase_Get(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestDatabase_Set(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestDatabase_Delete(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestDatabase_Exists(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -167,7 +167,7 @@ func TestDatabase_Exists(t *testing.T) {
 
 func TestDatabase_Executor(t *testing.T) {
 	mockDB, _ := mockdb.New()
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestDatabase_QueryBuilder(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestDatabase_SelectBuilder(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -239,7 +239,7 @@ func TestDatabase_InsertBuilder(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestDatabase_InsertFullBuilder(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestDatabase_ModifyBuilder(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestDatabase_RemoveBuilder(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestDatabase_ExecQuery(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -379,7 +379,7 @@ func TestDatabase_ExecQueryWithStatement(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -415,7 +415,7 @@ func TestDatabase_ExecSelect(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestDatabase_ExecUpdate(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestDatabase_ExecAggregate(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -503,7 +503,7 @@ func TestDatabase_ExecAggregateSum(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestDatabase_ExecAggregateSum(t *testing.T) {
 func TestDatabase_Atomic(t *testing.T) {
 	mockDB, _ := mockdb.New()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -555,7 +555,7 @@ func TestDatabase_Get_NotFound(t *testing.T) {
 	mockDB, _ := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -575,7 +575,7 @@ func TestDatabase_Get_QueryError(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -598,7 +598,7 @@ func TestDatabase_Delete_NotFound(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -620,7 +620,7 @@ func TestDatabase_Delete_ExecError(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -643,7 +643,7 @@ func TestDatabase_Exists_QueryError(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -668,7 +668,7 @@ func TestDatabase_GetTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -698,7 +698,7 @@ func TestDatabase_SetTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -735,7 +735,7 @@ func TestDatabase_DeleteTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -765,7 +765,7 @@ func TestDatabase_ExistsTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -795,7 +795,7 @@ func TestDatabase_ExecQueryTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -825,7 +825,7 @@ func TestDatabase_ExecSelectTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -861,7 +861,7 @@ func TestDatabase_ExecUpdateTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -903,7 +903,7 @@ func TestDatabase_ExecAggregateTx(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -930,7 +930,7 @@ func TestDatabase_GetTx_NotFound(t *testing.T) {
 	mockDB, _ := mockdb.New()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -954,7 +954,7 @@ func TestDatabase_DeleteTx_NotFound(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -981,7 +981,7 @@ func TestDatabase_GetTx_QueryError(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -1009,7 +1009,7 @@ func TestDatabase_DeleteTx_ExecError(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -1037,7 +1037,7 @@ func TestDatabase_ExistsTx_QueryError(t *testing.T) {
 	mockDB, _, cfg := mockdb.NewWithConfig()
 	ctx := context.Background()
 
-	db, err := NewDatabase[TestDBUser](mockDB, "test_users", "id", testDBRenderer)
+	db, err := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
 	if err != nil {
 		t.Fatalf("NewDatabase failed: %v", err)
 	}
@@ -1058,5 +1058,87 @@ func TestDatabase_ExistsTx_QueryError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "tx exists query error") {
 		t.Errorf("expected tx query error, got: %v", err)
+	}
+}
+
+// --- Primary Key Detection Tests ---
+
+type NoPKUser struct {
+	ID   int    `db:"id"`
+	Name string `db:"name"`
+}
+
+type MultiplePKUser struct {
+	ID1 int `db:"id1" constraints:"primarykey"`
+	ID2 int `db:"id2" constraints:"primarykey"`
+}
+
+type CommaPKUser struct {
+	ID   int    `db:"id" constraints:"primarykey,notnull"`
+	Name string `db:"name"`
+}
+
+type PKNoDBTag struct {
+	ID   int    `constraints:"primarykey"`
+	Name string `db:"name"`
+}
+
+type PKIgnoredDBTag struct {
+	ID   int    `db:"-" constraints:"primarykey"`
+	Name string `db:"name"`
+}
+
+func TestNewDatabase_NoPrimaryKey(t *testing.T) {
+	mockDB, _ := mockdb.New()
+	_, err := NewDatabase[NoPKUser](mockDB, "test", testDBRenderer)
+	if err == nil {
+		t.Fatal("expected ErrNoPrimaryKey")
+	}
+	if !errors.Is(err, ErrNoPrimaryKey) {
+		t.Errorf("expected ErrNoPrimaryKey, got: %v", err)
+	}
+}
+
+func TestNewDatabase_MultiplePrimaryKeys(t *testing.T) {
+	mockDB, _ := mockdb.New()
+	_, err := NewDatabase[MultiplePKUser](mockDB, "test", testDBRenderer)
+	if err == nil {
+		t.Fatal("expected ErrMultiplePrimaryKeys")
+	}
+	if !errors.Is(err, ErrMultiplePrimaryKeys) {
+		t.Errorf("expected ErrMultiplePrimaryKeys, got: %v", err)
+	}
+}
+
+func TestNewDatabase_PrimaryKeyInCommaList(t *testing.T) {
+	mockDB, _ := mockdb.New()
+	db, err := NewDatabase[CommaPKUser](mockDB, "test", testDBRenderer)
+	if err != nil {
+		t.Fatalf("NewDatabase failed: %v", err)
+	}
+	if db.keyCol != "id" {
+		t.Errorf("expected keyCol 'id', got %q", db.keyCol)
+	}
+}
+
+func TestNewDatabase_PrimaryKeyNoDBTag(t *testing.T) {
+	mockDB, _ := mockdb.New()
+	_, err := NewDatabase[PKNoDBTag](mockDB, "test", testDBRenderer)
+	if err == nil {
+		t.Fatal("expected ErrNoPrimaryKey")
+	}
+	if !errors.Is(err, ErrNoPrimaryKey) {
+		t.Errorf("expected ErrNoPrimaryKey, got: %v", err)
+	}
+}
+
+func TestNewDatabase_PrimaryKeyIgnoredDBTag(t *testing.T) {
+	mockDB, _ := mockdb.New()
+	_, err := NewDatabase[PKIgnoredDBTag](mockDB, "test", testDBRenderer)
+	if err == nil {
+		t.Fatal("expected ErrNoPrimaryKey")
+	}
+	if !errors.Is(err, ErrNoPrimaryKey) {
+		t.Errorf("expected ErrNoPrimaryKey, got: %v", err)
 	}
 }

--- a/docs/1.overview.md
+++ b/docs/1.overview.md
@@ -103,7 +103,7 @@ obj, _ := bucket.Get(ctx, "docs/report.json")
 For structured records with query capabilities.
 
 ```go
-db, _ := grub.NewDatabase[User](sqlxDB, "users", "id", sqlite.New())
+db, _ := grub.NewDatabase[User](sqlxDB, "users", sqlite.New())
 
 db.Set(ctx, "1", &User{ID: 1, Email: "alice@example.com"})
 user, _ := db.Get(ctx, "1")

--- a/docs/2.learn/2.concepts.md
+++ b/docs/2.learn/2.concepts.md
@@ -144,9 +144,17 @@ Databases provide CRUD operations on SQL tables with query capabilities.
 db, err := grub.NewDatabase[User](
     sqlxDB,        // *sqlx.DB connection
     "users",       // Table name
-    "id",          // Primary key column
     sqlite.New(),  // SQL dialect renderer
 )
+```
+
+The primary key column is derived automatically from struct tags:
+
+```go
+type User struct {
+    ID    int    `db:"id" constraints:"primarykey"`
+    Email string `db:"email"`
+}
 ```
 
 ### Operations

--- a/docs/2.learn/3.architecture.md
+++ b/docs/2.learn/3.architecture.md
@@ -139,7 +139,7 @@ All operations accept `context.Context` for cancellation and timeouts.
 
 ```go
 // Create database wrapper
-db, _ := grub.NewDatabase[User](sqlxDB, "users", "id", sqlite.New())
+db, _ := grub.NewDatabase[User](sqlxDB, "users", sqlite.New())
 
 // Use *Tx methods within a transaction
 tx, _ := sqlxDB.BeginTxx(ctx, nil)

--- a/docs/3.guides/1.providers.md
+++ b/docs/3.guides/1.providers.md
@@ -274,7 +274,7 @@ func main() {
     }
     defer db.Close()
 
-    users, err := grub.NewDatabase[User](db, "users", "id", postgres.New())
+    users, err := grub.NewDatabase[User](db, "users", postgres.New())
 }
 ```
 
@@ -289,7 +289,7 @@ import (
 )
 
 db, _ := sqlx.Connect("mysql", "user:pass@tcp(localhost:3306)/db")
-users, _ := grub.NewDatabase[User](db, "users", "id", mariadb.New())
+users, _ := grub.NewDatabase[User](db, "users", mariadb.New())
 ```
 
 ### SQLite
@@ -301,7 +301,7 @@ import (
 )
 
 db, _ := sqlx.Connect("sqlite", "./data.db")
-users, _ := grub.NewDatabase[User](db, "users", "id", sqlite.New())
+users, _ := grub.NewDatabase[User](db, "users", sqlite.New())
 ```
 
 ### SQL Server
@@ -313,7 +313,7 @@ import (
 )
 
 db, _ := sqlx.Connect("sqlserver", "sqlserver://user:pass@localhost?database=db")
-users, _ := grub.NewDatabase[User](db, "users", "id", mssql.New())
+users, _ := grub.NewDatabase[User](db, "users", mssql.New())
 ```
 
 ## Vector Provider Setup

--- a/docs/3.guides/4.testing.md
+++ b/docs/3.guides/4.testing.md
@@ -200,7 +200,7 @@ func setupTestDB(t *testing.T) *grub.Database[User] {
         email TEXT
     )`)
 
-    userDB, err := grub.NewDatabase[User](db, "users", "id", sqlite.New())
+    userDB, err := grub.NewDatabase[User](db, "users", sqlite.New())
     if err != nil {
         t.Fatal(err)
     }
@@ -331,7 +331,7 @@ func setupPostgresDB(t *testing.T) *grub.Database[User] {
     // Create schema
     db.MustExec(`CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT, email TEXT)`)
 
-    userDB, _ := grub.NewDatabase[User](db, "users", "id", postgres.New())
+    userDB, _ := grub.NewDatabase[User](db, "users", postgres.New())
     return userDB
 }
 ```

--- a/docs/4.cookbook/2.migrations.md
+++ b/docs/4.cookbook/2.migrations.md
@@ -389,10 +389,10 @@ Use grub's Database wrapper with different renderers:
 
 ```go
 // Development: SQLite
-devDB, _ := grub.NewDatabase[User](sqliteConn, "users", "id", sqlite.New())
+devDB, _ := grub.NewDatabase[User](sqliteConn, "users", sqlite.New())
 
 // Production: PostgreSQL
-prodDB, _ := grub.NewDatabase[User](pgConn, "users", "id", postgres.New())
+prodDB, _ := grub.NewDatabase[User](pgConn, "users", postgres.New())
 ```
 
 ### Data Export/Import

--- a/docs/4.cookbook/4.vector-search.md
+++ b/docs/4.cookbook/4.vector-search.md
@@ -95,7 +95,7 @@ import (
 )
 
 db, _ := sqlx.Connect("postgres", "postgres://user:pass@localhost/mydb?sslmode=disable")
-docs, _ := grub.NewDatabase[Document](db, "documents", "id", postgres.New())
+docs, _ := grub.NewDatabase[Document](db, "documents", postgres.New())
 ```
 
 ## CRUD Operations
@@ -220,7 +220,7 @@ func main() {
     }
     defer conn.Close()
 
-    docs, err := grub.NewDatabase[Document](conn, "documents", "id", postgres.New())
+    docs, err := grub.NewDatabase[Document](conn, "documents", postgres.New())
     if err != nil {
         log.Fatal(err)
     }

--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -40,6 +40,8 @@ Semantic errors returned by all providers.
 | `ErrIndexNotReady` | Index not loaded or initialized |
 | `ErrInvalidQuery` | Filter contains validation errors |
 | `ErrOperatorNotSupported` | Provider doesn't support filter operator |
+| `ErrNoPrimaryKey` | No field has `constraints:"primarykey"` tag |
+| `ErrMultiplePrimaryKeys` | Multiple fields have `primarykey` constraint |
 
 ```go
 if errors.Is(err, grub.ErrNotFound) {
@@ -289,7 +291,6 @@ Type-safe SQL database wrapper.
 func NewDatabase[T any](
     db *sqlx.DB,
     table string,
-    keyCol string,
     renderer astql.Renderer,
 ) (*Database[T], error)
 ```
@@ -298,14 +299,24 @@ Creates a new Database wrapper.
 
 - `db`: Database connection
 - `table`: Table name
-- `keyCol`: Primary key column name
 - `renderer`: SQL dialect renderer (postgres.New(), mariadb.New(), etc.)
 
-Use the `*Tx` method variants (GetTx, SetTx, etc.) for transaction support.
+The primary key column is automatically derived from struct tags. Mark the primary key field with `constraints:"primarykey"`:
 
 ```go
-db, err := grub.NewDatabase[User](sqlxDB, "users", "id", sqlite.New())
+type User struct {
+    ID    int    `db:"id" constraints:"primarykey"`
+    Email string `db:"email" constraints:"notnull,unique"`
+    Name  string `db:"name"`
+}
+
+db, err := grub.NewDatabase[User](sqlxDB, "users", sqlite.New())
 ```
+
+Returns `ErrNoPrimaryKey` if no field has the `primarykey` constraint.
+Returns `ErrMultiplePrimaryKeys` if multiple fields have the constraint (composite keys not supported).
+
+Use the `*Tx` method variants (GetTx, SetTx, etc.) for transaction support.
 
 ### Methods
 

--- a/docs/5.reference/2.providers.md
+++ b/docs/5.reference/2.providers.md
@@ -375,7 +375,7 @@ import (
 )
 
 db, _ := sqlx.Connect("postgres", dsn)
-users, _ := grub.NewDatabase[User](db, "users", "id", postgres.New())
+users, _ := grub.NewDatabase[User](db, "users", postgres.New())
 ```
 
 ### MariaDB

--- a/internal/shared/errors.go
+++ b/internal/shared/errors.go
@@ -49,4 +49,10 @@ var (
 
 	// ErrFilterNotSupported indicates the provider does not support metadata-only filtering.
 	ErrFilterNotSupported = errors.New("grub: filter not supported by provider")
+
+	// ErrNoPrimaryKey indicates no field has the primarykey constraint.
+	ErrNoPrimaryKey = errors.New("grub: no primary key defined in struct tags")
+
+	// ErrMultiplePrimaryKeys indicates multiple fields have the primarykey constraint.
+	ErrMultiplePrimaryKeys = errors.New("grub: multiple primary keys not supported")
 )

--- a/testing/integration/database/shared.go
+++ b/testing/integration/database/shared.go
@@ -99,7 +99,7 @@ func testGet(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -129,7 +129,7 @@ func testGetAtom(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -154,7 +154,7 @@ func testSet(t *testing.T, tc *TestContext) {
 	tc.Reset(t)
 	ctx := context.Background()
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -190,7 +190,7 @@ func testSetUpdate(t *testing.T, tc *TestContext) {
 	tc.Reset(t)
 	ctx := context.Background()
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -228,7 +228,7 @@ func testSetAtom(t *testing.T, tc *TestContext) {
 	tc.Reset(t)
 	ctx := context.Background()
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -271,7 +271,7 @@ func testDelete(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -291,7 +291,7 @@ func testDeleteNotFound(t *testing.T, tc *TestContext) {
 	tc.Reset(t)
 	ctx := context.Background()
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -318,7 +318,7 @@ func testQuery(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -347,7 +347,7 @@ func testQueryWithStatement(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -388,7 +388,7 @@ func testQueryAtom(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -424,7 +424,7 @@ func testSelect(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -457,7 +457,7 @@ func testSelectAtom(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -490,7 +490,7 @@ func testUpdate(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -539,7 +539,7 @@ func testAggregate(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -568,7 +568,7 @@ func testAggregateSum(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -603,7 +603,7 @@ func testQueryPagination(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -662,7 +662,7 @@ func testGetTx(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -687,7 +687,7 @@ func testSetTx(t *testing.T, tc *TestContext) {
 	tc.Reset(t)
 	ctx := context.Background()
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -733,7 +733,7 @@ func testDeleteTx(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -763,7 +763,7 @@ func testTransactionCommit(t *testing.T, tc *TestContext) {
 	tc.Reset(t)
 	ctx := context.Background()
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -806,7 +806,7 @@ func testTransactionRollback(t *testing.T, tc *TestContext) {
 	tc.Reset(t)
 	ctx := context.Background()
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -855,7 +855,7 @@ func testQueryTx(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -885,7 +885,7 @@ func testUpdateTx(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test record: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}
@@ -942,7 +942,7 @@ func testAggregateTx(t *testing.T, tc *TestContext) {
 		t.Fatalf("failed to insert test records: %v", err)
 	}
 
-	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", "id", tc.Renderer)
+	db, err := grub.NewDatabase[TestUser](tc.DB, "test_users", tc.Renderer)
 	if err != nil {
 		t.Fatalf("failed to create database: %v", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic primary-key detection from struct field tags.
  * New semantic errors for primary-key validation: ErrNoPrimaryKey, ErrMultiplePrimaryKeys.

* **Breaking Changes**
  * Constructor simplified: explicit primary-key argument removed; key is inferred from struct tags.

* **Documentation**
  * Examples, guides, and API docs updated to show the new constructor usage and primary-key tagging guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->