### PR TITLE
feat: opt-in lifecycle hooks for all storage types

### DIFF
--- a/docs/2.learn/2.concepts.md
+++ b/docs/2.learn/2.concepts.md
@@ -3,9 +3,10 @@ title: Core Concepts
 description: Stores, buckets, databases, and the primitives that power grub
 author: zoobzio
 published: 2025-01-07
-updated: 2025-01-07
+updated: 2026-01-28
 tags:
   - Concepts
+  - Hooks
   - Store
   - Bucket
   - Database
@@ -254,6 +255,70 @@ results, err := index.Query(ctx, queryVector, 10, filter)
 ```
 
 **Note:** Filter operator support varies by provider. See [Provider Reference](../5.reference/2.providers.md) for the operator support matrix.
+
+## Lifecycle Hooks
+
+Types can opt into lifecycle hooks by implementing one or more hook interfaces. When present, grub calls these hooks at specific points during CRUD operations across all four storage types.
+
+### Hook Interfaces
+
+| Interface | When Called | Effect of Error |
+|-----------|-----------|-----------------|
+| `BeforeSave` | Before persisting T | Aborts the write |
+| `AfterSave` | After successful persist | Signals post-save failure |
+| `AfterLoad` | After T is loaded and decoded | Signals broken data |
+| `BeforeDelete` | Before deletion | Aborts the delete |
+| `AfterDelete` | After successful deletion | Signals post-delete failure |
+
+All hooks receive `context.Context` and return `error`.
+
+### Usage
+
+Implement the interface on your type with a pointer receiver:
+
+```go
+type User struct {
+    ID    string `db:"id" constraints:"primarykey"`
+    Name  string `db:"name"`
+    Email string `db:"email"`
+}
+
+func (u *User) BeforeSave(ctx context.Context) error {
+    if u.Email == "" {
+        return errors.New("email is required")
+    }
+    return nil
+}
+
+func (u *User) AfterLoad(ctx context.Context) error {
+    u.Email = strings.ToLower(u.Email)
+    return nil
+}
+```
+
+Hooks are opt-in. Types that don't implement any hook interface work unchanged with zero overhead.
+
+### Delete Hooks
+
+Delete hooks are invoked on a zero-value `T` since delete operations only have a key/ID, not a loaded instance. They act as static guards or side-effects on the type:
+
+```go
+func (u *User) BeforeDelete(ctx context.Context) error {
+    // Guard or side-effect — no instance state available
+    return nil
+}
+```
+
+### Scope
+
+Hooks fire on all typed interactions:
+
+- **Store[T]:** Get, Set, Delete, GetBatch, SetBatch
+- **Bucket[T]:** Get, Put, Delete (hooks fire on the `T` payload, not `Object[T]`)
+- **Database[T]:** Get, Set, Delete, and all query builder/statement execution results
+- **Index[T]:** Upsert, UpsertBatch, Get, Delete, DeleteBatch, Search, Query, Filter
+
+Atomic views do **not** trigger hooks — they operate below the type-aware layer.
 
 ## Codecs
 

--- a/docs/2.learn/3.architecture.md
+++ b/docs/2.learn/3.architecture.md
@@ -3,7 +3,7 @@ title: Architecture
 description: Internal design, concurrency model, and atomization
 author: zoobzio
 published: 2025-01-07
-updated: 2025-01-07
+updated: 2026-01-28
 tags:
   - Architecture
   - Internals
@@ -36,12 +36,23 @@ This document covers grub's internal design for those who need deeper understand
 1. Application calls `store.Get(ctx, "key")`
 2. Wrapper calls `provider.Get(ctx, "key")` → `[]byte`
 3. Codec decodes bytes → typed value
-4. Wrapper returns `*T`
+4. If T implements `AfterLoad`, the hook is called
+5. Wrapper returns `*T`
 
 **Data flow for Set:**
 1. Application calls `store.Set(ctx, "key", &value, ttl)`
-2. Codec encodes value → `[]byte`
-3. Wrapper calls `provider.Set(ctx, "key", bytes, ttl)`
+2. If T implements `BeforeSave`, the hook is called (error aborts)
+3. Codec encodes value → `[]byte`
+4. Wrapper calls `provider.Set(ctx, "key", bytes, ttl)`
+5. If T implements `AfterSave`, the hook is called
+
+**Data flow for Delete:**
+1. Application calls `store.Delete(ctx, "key")`
+2. If T implements `BeforeDelete`, the hook is called on a zero-value T (error aborts)
+3. Wrapper calls `provider.Delete(ctx, "key")`
+4. If T implements `AfterDelete`, the hook is called on a zero-value T
+
+Hooks are opt-in. Types that don't implement any hook interface skip these steps with zero overhead. Hooks fire at the wrapper layer — atomic views and raw provider calls do not trigger hooks.
 
 ## Wrapper Implementation
 

--- a/docs/3.guides/2.lifecycle.md
+++ b/docs/3.guides/2.lifecycle.md
@@ -3,9 +3,10 @@ title: Lifecycle Operations
 description: CRUD operations, batch processing, and listing
 author: zoobzio
 published: 2025-01-07
-updated: 2025-01-07
+updated: 2026-01-28
 tags:
   - Operations
+  - Hooks
   - CRUD
   - Lifecycle
 ---
@@ -284,6 +285,105 @@ users, err := db.ExecQuery(ctx, grub.QueryAll, nil)
 // Count records
 count, err := db.ExecAggregate(ctx, grub.CountAll, nil)
 ```
+
+## Lifecycle Hooks
+
+Types can opt into lifecycle hooks that fire automatically during CRUD operations. Implement one or more hook interfaces on your type to add validation, normalization, or side-effects.
+
+### Hook Interfaces
+
+```go
+type BeforeSave interface {
+    BeforeSave(ctx context.Context) error
+}
+
+type AfterSave interface {
+    AfterSave(ctx context.Context) error
+}
+
+type AfterLoad interface {
+    AfterLoad(ctx context.Context) error
+}
+
+type BeforeDelete interface {
+    BeforeDelete(ctx context.Context) error
+}
+
+type AfterDelete interface {
+    AfterDelete(ctx context.Context) error
+}
+```
+
+### Example: Validation and Normalization
+
+```go
+type User struct {
+    ID    string `db:"id" constraints:"primarykey"`
+    Name  string `db:"name"`
+    Email string `db:"email"`
+}
+
+// Validate before any write
+func (u *User) BeforeSave(ctx context.Context) error {
+    if u.Email == "" {
+        return errors.New("email is required")
+    }
+    return nil
+}
+
+// Normalize after any read
+func (u *User) AfterLoad(ctx context.Context) error {
+    u.Email = strings.ToLower(u.Email)
+    return nil
+}
+```
+
+These hooks fire automatically on all typed operations:
+
+```go
+// BeforeSave fires before the write — returns error if email is empty
+err := store.Set(ctx, "user:1", &User{Name: "Alice"}, 0)
+// err: "email is required"
+
+// AfterLoad fires after decode — email is normalized
+user, err := store.Get(ctx, "user:1")
+// user.Email is lowercase
+```
+
+### Hook Firing Points
+
+| Storage Type | Save Hooks | Load Hooks | Delete Hooks |
+|-------------|-----------|-----------|-------------|
+| Store[T] | Set, SetBatch | Get, GetBatch | Delete |
+| Bucket[T] | Put | Get | Delete |
+| Database[T] | Set, SetTx, Insert, InsertFull (all builder paths) | Get, GetTx, Query, Select, Modify, ExecQuery, ExecSelect, ExecUpdate (and Tx variants) | Delete, DeleteTx |
+| Index[T] | Upsert, UpsertBatch | Get, Search, Query, Filter | Delete, DeleteBatch |
+
+### Batch Behavior
+
+For batch operations, hooks fire per-item:
+
+- **SetBatch:** `BeforeSave` runs on each item before encoding. If any fails, the entire batch is aborted. `AfterSave` runs on each item after the batch succeeds.
+- **GetBatch:** `AfterLoad` runs on each decoded item.
+- **UpsertBatch:** `BeforeSave` runs on each metadata item before encoding.
+
+### Delete Hooks
+
+Delete hooks are invoked on a zero-value `T` because delete operations only receive a key/ID. They act as static guards or side-effects:
+
+```go
+func (u *User) BeforeDelete(ctx context.Context) error {
+    // No instance state available — use for static guards
+    return nil
+}
+```
+
+### What Hooks Don't Cover
+
+- **Atomic views** do not trigger hooks (they operate below the type-aware layer)
+- **ExecAggregate** does not trigger hooks (returns `float64`, not `*T`)
+- **List/Exists** operations do not trigger hooks (no T instance involved)
+- **Remove** (delete builder) does not trigger hooks (returns `int64`, not `*T`)
 
 ## Common Patterns
 

--- a/docs/5.reference/1.api.md
+++ b/docs/5.reference/1.api.md
@@ -3,7 +3,7 @@ title: API Reference
 description: Complete API documentation for grub
 author: zoobzio
 published: 2025-01-07
-updated: 2025-01-07
+updated: 2026-01-28
 tags:
   - API
   - Reference
@@ -889,6 +889,56 @@ type VectorProvider interface {
     Filter(ctx context.Context, filter *vecna.Filter, limit int) ([]VectorResult, error)
     List(ctx context.Context, prefix string, limit int) ([]string, error)
     Exists(ctx context.Context, id string) (bool, error)
+}
+```
+
+### BeforeSave
+
+Called before persisting T. Return an error to abort the write.
+
+```go
+type BeforeSave interface {
+    BeforeSave(ctx context.Context) error
+}
+```
+
+### AfterSave
+
+Called after T has been successfully persisted.
+
+```go
+type AfterSave interface {
+    AfterSave(ctx context.Context) error
+}
+```
+
+### AfterLoad
+
+Called after T has been loaded and decoded.
+
+```go
+type AfterLoad interface {
+    AfterLoad(ctx context.Context) error
+}
+```
+
+### BeforeDelete
+
+Called before deleting a record. Invoked on a zero-value T (no loaded state).
+
+```go
+type BeforeDelete interface {
+    BeforeDelete(ctx context.Context) error
+}
+```
+
+### AfterDelete
+
+Called after a record has been successfully deleted. Invoked on a zero-value T (no loaded state).
+
+```go
+type AfterDelete interface {
+    AfterDelete(ctx context.Context) error
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/zoobzio/atom v1.0.0
 	github.com/zoobzio/edamame v1.0.1
 	github.com/zoobzio/sentinel v1.0.2
-	github.com/zoobzio/soy v1.0.2
+	github.com/zoobzio/soy v1.0.3
 	github.com/zoobzio/vecna v0.0.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/zoobzio/edamame v1.0.1 h1:Mynav/EvOEVjQ36JrKm9I3k7nm9t3VgGC1bpyw2rFMA
 github.com/zoobzio/edamame v1.0.1/go.mod h1:UVfTcjd//Nfs2lLNWrQqomd0O9f0ic31PftXz3KvyWw=
 github.com/zoobzio/sentinel v1.0.2 h1:hTs5Ke2Vi0VgOkoHSJF9G3BYnxTQjMbvOH+qbbQLaoY=
 github.com/zoobzio/sentinel v1.0.2/go.mod h1:gtsD0AYlTEI8ajpEQ3azb7BDZicdsESOB1dJpQqgDKc=
-github.com/zoobzio/soy v1.0.2 h1:nNymMAvjZRJ1rHJFDDOCTFC7/mdKcgXuFE4JyAKT0FM=
-github.com/zoobzio/soy v1.0.2/go.mod h1:QbHYncFp2bUBfZegzSrTAcDoFKlLGQESKNY43OUu5q4=
+github.com/zoobzio/soy v1.0.3 h1:Qkl/v2XHv2bd/zo8YfVtIygKtzHclRwvXFnGVpRpwbg=
+github.com/zoobzio/soy v1.0.3/go.mod h1:QbHYncFp2bUBfZegzSrTAcDoFKlLGQESKNY43OUu5q4=
 github.com/zoobzio/vecna v0.0.2 h1:n4SEXmp1k5JrparT7PfPS6RTH4xd/NTkvXZwQg7r8/Q=
 github.com/zoobzio/vecna v0.0.2/go.mod h1:NQxYrpZSp8Lxqk5n8f3UB95bqMdG1g+tF1Sxxawds6Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,84 @@
+package grub
+
+import "context"
+
+// BeforeSave is called before persisting T. Return an error to abort the operation.
+type BeforeSave interface {
+	BeforeSave(ctx context.Context) error
+}
+
+// AfterSave is called after T has been successfully persisted.
+// Return an error to signal a post-save invariant failure.
+type AfterSave interface {
+	AfterSave(ctx context.Context) error
+}
+
+// AfterLoad is called after T has been loaded and decoded.
+// Return an error to signal a post-load invariant failure.
+type AfterLoad interface {
+	AfterLoad(ctx context.Context) error
+}
+
+// BeforeDelete is called before deleting a record.
+// Invoked on a zero-value T (no loaded state). Return an error to abort the operation.
+type BeforeDelete interface {
+	BeforeDelete(ctx context.Context) error
+}
+
+// AfterDelete is called after a record has been successfully deleted.
+// Invoked on a zero-value T (no loaded state). Return an error to signal a post-delete failure.
+type AfterDelete interface {
+	AfterDelete(ctx context.Context) error
+}
+
+// callBeforeSave calls BeforeSave on value if T implements the interface.
+func callBeforeSave[T any](ctx context.Context, value *T) error {
+	if h, ok := any(value).(BeforeSave); ok {
+		return h.BeforeSave(ctx)
+	}
+	return nil
+}
+
+// callAfterSave calls AfterSave on value if T implements the interface.
+func callAfterSave[T any](ctx context.Context, value *T) error {
+	if h, ok := any(value).(AfterSave); ok {
+		return h.AfterSave(ctx)
+	}
+	return nil
+}
+
+// callAfterLoad calls AfterLoad on value if T implements the interface.
+func callAfterLoad[T any](ctx context.Context, value *T) error {
+	if h, ok := any(value).(AfterLoad); ok {
+		return h.AfterLoad(ctx)
+	}
+	return nil
+}
+
+// callAfterLoadSlice calls AfterLoad on each element if T implements the interface.
+func callAfterLoadSlice[T any](ctx context.Context, values []*T) error {
+	for _, v := range values {
+		if err := callAfterLoad(ctx, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// callBeforeDelete calls BeforeDelete on a zero-value T if T implements the interface.
+func callBeforeDelete[T any](ctx context.Context) error {
+	var zero T
+	if h, ok := any(&zero).(BeforeDelete); ok {
+		return h.BeforeDelete(ctx)
+	}
+	return nil
+}
+
+// callAfterDelete calls AfterDelete on a zero-value T if T implements the interface.
+func callAfterDelete[T any](ctx context.Context) error {
+	var zero T
+	if h, ok := any(&zero).(AfterDelete); ok {
+		return h.AfterDelete(ctx)
+	}
+	return nil
+}

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -1,0 +1,904 @@
+package grub
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	astqlsqlite "github.com/zoobzio/astql/sqlite"
+	"github.com/zoobzio/grub/internal/mockdb"
+)
+
+var errHook = errors.New("hook error")
+
+// hookedRecord implements all lifecycle hooks and tracks calls.
+type hookedRecord struct {
+	ID   int    `json:"id" atom:"id"`
+	Name string `json:"name" atom:"name"`
+
+	beforeSaveCalled   bool
+	afterSaveCalled    bool
+	afterLoadCalled    bool
+	beforeDeleteCalled bool
+	afterDeleteCalled  bool
+}
+
+func (h *hookedRecord) BeforeSave(_ context.Context) error {
+	h.beforeSaveCalled = true
+	return nil
+}
+
+func (h *hookedRecord) AfterSave(_ context.Context) error {
+	h.afterSaveCalled = true
+	return nil
+}
+
+func (h *hookedRecord) AfterLoad(_ context.Context) error {
+	h.afterLoadCalled = true
+	return nil
+}
+
+func (h *hookedRecord) BeforeDelete(_ context.Context) error {
+	h.beforeDeleteCalled = true
+	return nil
+}
+
+func (h *hookedRecord) AfterDelete(_ context.Context) error {
+	h.afterDeleteCalled = true
+	return nil
+}
+
+// failingBeforeSave implements BeforeSave that returns an error.
+type failingBeforeSave struct {
+	ID   int    `json:"id" atom:"id"`
+	Name string `json:"name" atom:"name"`
+}
+
+func (*failingBeforeSave) BeforeSave(_ context.Context) error { return errHook }
+
+// failingAfterSave implements AfterSave that returns an error.
+type failingAfterSave struct {
+	ID   int    `json:"id" atom:"id"`
+	Name string `json:"name" atom:"name"`
+}
+
+func (*failingAfterSave) AfterSave(_ context.Context) error { return errHook }
+
+// failingAfterLoad implements AfterLoad that returns an error.
+type failingAfterLoad struct {
+	ID   int    `json:"id" atom:"id"`
+	Name string `json:"name" atom:"name"`
+}
+
+func (*failingAfterLoad) AfterLoad(_ context.Context) error { return errHook }
+
+// failingBeforeDelete implements BeforeDelete that returns an error.
+type failingBeforeDelete struct {
+	ID   int    `json:"id" atom:"id"`
+	Name string `json:"name" atom:"name"`
+}
+
+func (*failingBeforeDelete) BeforeDelete(_ context.Context) error { return errHook }
+
+// failingAfterDelete implements AfterDelete that returns an error.
+type failingAfterDelete struct {
+	ID   int    `json:"id" atom:"id"`
+	Name string `json:"name" atom:"name"`
+}
+
+func (*failingAfterDelete) AfterDelete(_ context.Context) error { return errHook }
+
+// failingBeforeSaveDBUser is a Database-compatible model whose BeforeSave fails.
+type failingBeforeSaveDBUser struct {
+	ID    int    `db:"id" constraints:"primarykey"`
+	Email string `db:"email" constraints:"notnull,unique"`
+	Name  string `db:"name" constraints:"notnull"`
+	Age   *int   `db:"age"`
+}
+
+func (*failingBeforeSaveDBUser) BeforeSave(_ context.Context) error { return errHook }
+
+// failingBeforeDeleteDBUser is a Database-compatible model whose BeforeDelete fails.
+type failingBeforeDeleteDBUser struct {
+	ID    int    `db:"id" constraints:"primarykey"`
+	Email string `db:"email" constraints:"notnull,unique"`
+	Name  string `db:"name" constraints:"notnull"`
+	Age   *int   `db:"age"`
+}
+
+func (*failingBeforeDeleteDBUser) BeforeDelete(_ context.Context) error { return errHook }
+
+// ============================================================
+// Helper function tests
+// ============================================================
+
+func TestCallBeforeSave_NoInterface(t *testing.T) {
+	rec := &testRecord{ID: 1, Name: "test"}
+	if err := callBeforeSave(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCallAfterSave_NoInterface(t *testing.T) {
+	rec := &testRecord{ID: 1, Name: "test"}
+	if err := callAfterSave(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCallAfterLoad_NoInterface(t *testing.T) {
+	rec := &testRecord{ID: 1, Name: "test"}
+	if err := callAfterLoad(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCallBeforeDelete_NoInterface(t *testing.T) {
+	if err := callBeforeDelete[testRecord](context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCallAfterDelete_NoInterface(t *testing.T) {
+	if err := callAfterDelete[testRecord](context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCallAfterLoadSlice(t *testing.T) {
+	ctx := context.Background()
+	values := []*hookedRecord{
+		{ID: 1, Name: "a"},
+		{ID: 2, Name: "b"},
+	}
+	if err := callAfterLoadSlice(ctx, values); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, v := range values {
+		if !v.afterLoadCalled {
+			t.Errorf("AfterLoad not called on element %d", i)
+		}
+	}
+}
+
+func TestCallAfterLoadSlice_Error(t *testing.T) {
+	ctx := context.Background()
+	values := []*failingAfterLoad{{ID: 1, Name: "a"}}
+	err := callAfterLoadSlice(ctx, values)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestCallAfterLoadSlice_Empty(t *testing.T) {
+	if err := callAfterLoadSlice[hookedRecord](context.Background(), nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ============================================================
+// Database[T] hook tests (mockdb — query capture only)
+// ============================================================
+
+func TestDatabaseHooks_SetBeforeSaveError(t *testing.T) {
+	db, _ := mockdb.New()
+	d, err := NewDatabase[failingBeforeSaveDBUser](db, "test_users", astqlsqlite.New())
+	if err != nil {
+		t.Fatalf("NewDatabase failed: %v", err)
+	}
+	ctx := context.Background()
+	rec := &failingBeforeSaveDBUser{ID: 1, Email: "a@b.c", Name: "test"}
+	err = d.Set(ctx, "1", rec)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestDatabaseHooks_SetTxBeforeSaveError(t *testing.T) {
+	db, _ := mockdb.New()
+	d, err := NewDatabase[failingBeforeSaveDBUser](db, "test_users", astqlsqlite.New())
+	if err != nil {
+		t.Fatalf("NewDatabase failed: %v", err)
+	}
+	ctx := context.Background()
+	tx, _ := db.Beginx()
+	rec := &failingBeforeSaveDBUser{ID: 1, Email: "a@b.c", Name: "test"}
+	err = d.SetTx(ctx, tx, "1", rec)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestDatabaseHooks_DeleteBeforeDeleteError(t *testing.T) {
+	db, _ := mockdb.New()
+	d, err := NewDatabase[failingBeforeDeleteDBUser](db, "test_users", astqlsqlite.New())
+	if err != nil {
+		t.Fatalf("NewDatabase failed: %v", err)
+	}
+	ctx := context.Background()
+	err = d.Delete(ctx, "1")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestDatabaseHooks_DeleteTxBeforeDeleteError(t *testing.T) {
+	db, _ := mockdb.New()
+	d, err := NewDatabase[failingBeforeDeleteDBUser](db, "test_users", astqlsqlite.New())
+	if err != nil {
+		t.Fatalf("NewDatabase failed: %v", err)
+	}
+	ctx := context.Background()
+	tx, _ := db.Beginx()
+	err = d.DeleteTx(ctx, tx, "1")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+// ============================================================
+// Store[T] hook tests
+// ============================================================
+
+func TestStoreHooks_SetCallsBeforeAndAfterSave(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[hookedRecord](provider)
+	ctx := context.Background()
+
+	rec := &hookedRecord{ID: 1, Name: "test"}
+	if err := store.Set(ctx, "k", rec, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rec.beforeSaveCalled {
+		t.Error("BeforeSave not called")
+	}
+	if !rec.afterSaveCalled {
+		t.Error("AfterSave not called")
+	}
+}
+
+func TestStoreHooks_SetBeforeSaveError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingBeforeSave](provider)
+	ctx := context.Background()
+
+	rec := &failingBeforeSave{ID: 1, Name: "test"}
+	err := store.Set(ctx, "k", rec, 0)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+	if _, ok := provider.data["k"]; ok {
+		t.Error("provider.Set should not have been called")
+	}
+}
+
+func TestStoreHooks_SetAfterSaveError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingAfterSave](provider)
+	ctx := context.Background()
+
+	rec := &failingAfterSave{ID: 1, Name: "test"}
+	err := store.Set(ctx, "k", rec, 0)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestStoreHooks_GetCallsAfterLoad(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[hookedRecord](provider)
+	ctx := context.Background()
+
+	data, _ := JSONCodec{}.Encode(&hookedRecord{ID: 1, Name: "test"})
+	provider.data["k"] = data
+
+	result, err := store.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.afterLoadCalled {
+		t.Error("AfterLoad not called")
+	}
+}
+
+func TestStoreHooks_GetAfterLoadError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingAfterLoad](provider)
+	ctx := context.Background()
+
+	data, _ := JSONCodec{}.Encode(&failingAfterLoad{ID: 1, Name: "test"})
+	provider.data["k"] = data
+
+	_, err := store.Get(ctx, "k")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestStoreHooks_DeleteCallsHooks(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[hookedRecord](provider)
+	ctx := context.Background()
+
+	provider.data["k"] = []byte(`{}`)
+
+	if err := store.Delete(ctx, "k"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStoreHooks_DeleteBeforeDeleteError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingBeforeDelete](provider)
+	ctx := context.Background()
+
+	provider.data["k"] = []byte(`{}`)
+
+	err := store.Delete(ctx, "k")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+	if _, ok := provider.data["k"]; !ok {
+		t.Error("provider.Delete should not have been called")
+	}
+}
+
+func TestStoreHooks_DeleteAfterDeleteError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingAfterDelete](provider)
+	ctx := context.Background()
+
+	provider.data["k"] = []byte(`{}`)
+
+	err := store.Delete(ctx, "k")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestStoreHooks_GetBatchCallsAfterLoad(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[hookedRecord](provider)
+	ctx := context.Background()
+
+	data, _ := JSONCodec{}.Encode(&hookedRecord{ID: 1, Name: "a"})
+	provider.data["a"] = data
+	data, _ = JSONCodec{}.Encode(&hookedRecord{ID: 2, Name: "b"})
+	provider.data["b"] = data
+
+	results, err := store.GetBatch(ctx, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for k, v := range results {
+		if !v.afterLoadCalled {
+			t.Errorf("AfterLoad not called for key %s", k)
+		}
+	}
+}
+
+func TestStoreHooks_GetBatchAfterLoadError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingAfterLoad](provider)
+	ctx := context.Background()
+
+	data, _ := JSONCodec{}.Encode(&failingAfterLoad{ID: 1, Name: "a"})
+	provider.data["a"] = data
+
+	_, err := store.GetBatch(ctx, []string{"a"})
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestStoreHooks_SetBatchCallsBeforeAndAfterSave(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[hookedRecord](provider)
+	ctx := context.Background()
+
+	items := map[string]*hookedRecord{
+		"a": {ID: 1, Name: "a"},
+		"b": {ID: 2, Name: "b"},
+	}
+	if err := store.SetBatch(ctx, items, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for k, v := range items {
+		if !v.beforeSaveCalled {
+			t.Errorf("BeforeSave not called for key %s", k)
+		}
+		if !v.afterSaveCalled {
+			t.Errorf("AfterSave not called for key %s", k)
+		}
+	}
+}
+
+func TestStoreHooks_SetBatchBeforeSaveError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingBeforeSave](provider)
+	ctx := context.Background()
+
+	items := map[string]*failingBeforeSave{"a": {ID: 1, Name: "a"}}
+	err := store.SetBatch(ctx, items, 0)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestStoreHooks_SetBatchAfterSaveError(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[failingAfterSave](provider)
+	ctx := context.Background()
+
+	items := map[string]*failingAfterSave{"a": {ID: 1, Name: "a"}}
+	err := store.SetBatch(ctx, items, 0)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestStoreHooks_NoHookType(t *testing.T) {
+	provider := newMockStoreProvider()
+	store := NewStore[testRecord](provider)
+	ctx := context.Background()
+
+	rec := &testRecord{ID: 1, Name: "test"}
+	if err := store.Set(ctx, "k", rec, 0); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result, err := store.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Name != "test" {
+		t.Errorf("expected name 'test', got %q", result.Name)
+	}
+	if err := store.Delete(ctx, "k"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ============================================================
+// Bucket[T] hook tests
+// ============================================================
+
+func TestBucketHooks_PutCallsBeforeAndAfterSave(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[hookedRecord](provider)
+	ctx := context.Background()
+
+	obj := &Object[hookedRecord]{
+		Key:         "k",
+		ContentType: "application/json",
+		Data:        hookedRecord{ID: 1, Name: "test"},
+	}
+	if err := bucket.Put(ctx, obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !obj.Data.beforeSaveCalled {
+		t.Error("BeforeSave not called")
+	}
+	if !obj.Data.afterSaveCalled {
+		t.Error("AfterSave not called")
+	}
+}
+
+func TestBucketHooks_PutBeforeSaveError(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[failingBeforeSave](provider)
+	ctx := context.Background()
+
+	obj := &Object[failingBeforeSave]{Key: "k", Data: failingBeforeSave{ID: 1, Name: "test"}}
+	err := bucket.Put(ctx, obj)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestBucketHooks_PutAfterSaveError(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[failingAfterSave](provider)
+	ctx := context.Background()
+
+	obj := &Object[failingAfterSave]{Key: "k", Data: failingAfterSave{ID: 1, Name: "test"}}
+	err := bucket.Put(ctx, obj)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestBucketHooks_GetCallsAfterLoad(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[hookedRecord](provider)
+	ctx := context.Background()
+
+	data, _ := JSONCodec{}.Encode(&hookedRecord{ID: 1, Name: "test"})
+	provider.data["k"] = data
+	provider.info["k"] = &ObjectInfo{Key: "k", ContentType: "application/json", Size: int64(len(data))}
+
+	result, err := bucket.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Data.afterLoadCalled {
+		t.Error("AfterLoad not called")
+	}
+}
+
+func TestBucketHooks_GetAfterLoadError(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[failingAfterLoad](provider)
+	ctx := context.Background()
+
+	data, _ := JSONCodec{}.Encode(&failingAfterLoad{ID: 1, Name: "test"})
+	provider.data["k"] = data
+	provider.info["k"] = &ObjectInfo{Key: "k", ContentType: "application/json", Size: int64(len(data))}
+
+	_, err := bucket.Get(ctx, "k")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestBucketHooks_DeleteBeforeDeleteError(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[failingBeforeDelete](provider)
+	ctx := context.Background()
+
+	provider.data["k"] = []byte(`{}`)
+	provider.info["k"] = &ObjectInfo{Key: "k"}
+
+	err := bucket.Delete(ctx, "k")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestBucketHooks_DeleteAfterDeleteError(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[failingAfterDelete](provider)
+	ctx := context.Background()
+
+	provider.data["k"] = []byte(`{}`)
+	provider.info["k"] = &ObjectInfo{Key: "k"}
+
+	err := bucket.Delete(ctx, "k")
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestBucketHooks_NoHookType(t *testing.T) {
+	provider := newMockBucketProvider()
+	bucket := NewBucket[testRecord](provider)
+	ctx := context.Background()
+
+	obj := &Object[testRecord]{
+		Key:         "k",
+		ContentType: "application/json",
+		Data:        testRecord{ID: 1, Name: "test"},
+	}
+	if err := bucket.Put(ctx, obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result, err := bucket.Get(ctx, "k")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Data.Name != "test" {
+		t.Errorf("expected name 'test', got %q", result.Data.Name)
+	}
+}
+
+// ============================================================
+// Index[T] hook tests
+// ============================================================
+
+func TestIndexHooks_UpsertCallsBeforeAndAfterSave(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[hookedRecord](provider)
+	ctx := context.Background()
+
+	meta := &hookedRecord{ID: 1, Name: "test"}
+	if err := index.Upsert(ctx, uuid.New(), []float32{1.0, 2.0}, meta); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !meta.beforeSaveCalled {
+		t.Error("BeforeSave not called")
+	}
+	if !meta.afterSaveCalled {
+		t.Error("AfterSave not called")
+	}
+}
+
+func TestIndexHooks_UpsertBeforeSaveError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingBeforeSave](provider)
+	ctx := context.Background()
+
+	meta := &failingBeforeSave{ID: 1, Name: "test"}
+	err := index.Upsert(ctx, uuid.New(), []float32{1.0}, meta)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_UpsertAfterSaveError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterSave](provider)
+	ctx := context.Background()
+
+	meta := &failingAfterSave{ID: 1, Name: "test"}
+	err := index.Upsert(ctx, uuid.New(), []float32{1.0}, meta)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_UpsertBatchCallsBeforeAndAfterSave(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[hookedRecord](provider)
+	ctx := context.Background()
+
+	vectors := []Vector[hookedRecord]{
+		{ID: uuid.New(), Vector: []float32{1.0}, Metadata: hookedRecord{ID: 1, Name: "a"}},
+		{ID: uuid.New(), Vector: []float32{2.0}, Metadata: hookedRecord{ID: 2, Name: "b"}},
+	}
+	if err := index.UpsertBatch(ctx, vectors); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, v := range vectors {
+		if !v.Metadata.beforeSaveCalled {
+			t.Errorf("BeforeSave not called for vector %d", i)
+		}
+		if !v.Metadata.afterSaveCalled {
+			t.Errorf("AfterSave not called for vector %d", i)
+		}
+	}
+}
+
+func TestIndexHooks_UpsertBatchBeforeSaveError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingBeforeSave](provider)
+	ctx := context.Background()
+
+	vectors := []Vector[failingBeforeSave]{
+		{ID: uuid.New(), Vector: []float32{1.0}, Metadata: failingBeforeSave{ID: 1}},
+	}
+	err := index.UpsertBatch(ctx, vectors)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_UpsertBatchAfterSaveError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterSave](provider)
+	ctx := context.Background()
+
+	vectors := []Vector[failingAfterSave]{
+		{ID: uuid.New(), Vector: []float32{1.0}, Metadata: failingAfterSave{ID: 1}},
+	}
+	err := index.UpsertBatch(ctx, vectors)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_DeleteBatchProviderError(t *testing.T) {
+	provider := newMockVectorProvider()
+	provider.deleteErr = errors.New("provider error")
+	index := NewIndex[testRecord](provider)
+	ctx := context.Background()
+
+	err := index.DeleteBatch(ctx, []uuid.UUID{uuid.New()})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestIndexHooks_GetCallsAfterLoad(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[hookedRecord](provider)
+	ctx := context.Background()
+
+	id := uuid.New()
+	meta, _ := JSONCodec{}.Encode(&hookedRecord{ID: 1, Name: "test"})
+	provider.vectors[id] = vectorEntry{vector: []float32{1.0}, metadata: meta}
+
+	result, err := index.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Metadata.afterLoadCalled {
+		t.Error("AfterLoad not called")
+	}
+}
+
+func TestIndexHooks_GetAfterLoadError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterLoad](provider)
+	ctx := context.Background()
+
+	id := uuid.New()
+	meta, _ := JSONCodec{}.Encode(&failingAfterLoad{ID: 1, Name: "test"})
+	provider.vectors[id] = vectorEntry{vector: []float32{1.0}, metadata: meta}
+
+	_, err := index.Get(ctx, id)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_SearchCallsAfterLoad(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[hookedRecord](provider)
+	ctx := context.Background()
+
+	meta, _ := JSONCodec{}.Encode(&hookedRecord{ID: 1, Name: "test"})
+	provider.vectors[uuid.New()] = vectorEntry{vector: []float32{1.0, 0.0}, metadata: meta}
+	meta, _ = JSONCodec{}.Encode(&hookedRecord{ID: 2, Name: "test2"})
+	provider.vectors[uuid.New()] = vectorEntry{vector: []float32{0.0, 1.0}, metadata: meta}
+
+	results, err := index.Search(ctx, []float32{1.0, 0.0}, 2, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, v := range results {
+		if !v.Metadata.afterLoadCalled {
+			t.Errorf("AfterLoad not called for result %d", i)
+		}
+	}
+}
+
+func TestIndexHooks_SearchAfterLoadError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterLoad](provider)
+	ctx := context.Background()
+
+	meta, _ := JSONCodec{}.Encode(&failingAfterLoad{ID: 1})
+	provider.vectors[uuid.New()] = vectorEntry{vector: []float32{1.0}, metadata: meta}
+
+	_, err := index.Search(ctx, []float32{1.0}, 1, nil)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_QueryCallsAfterLoad(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[hookedRecord](provider)
+	ctx := context.Background()
+
+	meta, _ := JSONCodec{}.Encode(&hookedRecord{ID: 1, Name: "test"})
+	provider.vectors[uuid.New()] = vectorEntry{vector: []float32{1.0}, metadata: meta}
+
+	results, err := index.Query(ctx, []float32{1.0}, 1, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Metadata.afterLoadCalled {
+		t.Error("AfterLoad not called")
+	}
+}
+
+func TestIndexHooks_QueryAfterLoadError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterLoad](provider)
+	ctx := context.Background()
+
+	meta, _ := JSONCodec{}.Encode(&failingAfterLoad{ID: 1})
+	provider.vectors[uuid.New()] = vectorEntry{vector: []float32{1.0}, metadata: meta}
+
+	_, err := index.Query(ctx, []float32{1.0}, 1, nil)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_FilterCallsAfterLoad(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[hookedRecord](provider)
+	ctx := context.Background()
+
+	meta, _ := JSONCodec{}.Encode(&hookedRecord{ID: 1, Name: "test"})
+	provider.vectors[uuid.New()] = vectorEntry{vector: []float32{1.0}, metadata: meta}
+
+	results, err := index.Filter(ctx, nil, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Metadata.afterLoadCalled {
+		t.Error("AfterLoad not called")
+	}
+}
+
+func TestIndexHooks_FilterAfterLoadError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterLoad](provider)
+	ctx := context.Background()
+
+	meta, _ := JSONCodec{}.Encode(&failingAfterLoad{ID: 1})
+	provider.vectors[uuid.New()] = vectorEntry{vector: []float32{1.0}, metadata: meta}
+
+	_, err := index.Filter(ctx, nil, 0)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_DeleteBeforeDeleteError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingBeforeDelete](provider)
+	ctx := context.Background()
+
+	id := uuid.New()
+	provider.vectors[id] = vectorEntry{vector: []float32{1.0}}
+
+	err := index.Delete(ctx, id)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_DeleteAfterDeleteError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterDelete](provider)
+	ctx := context.Background()
+
+	id := uuid.New()
+	provider.vectors[id] = vectorEntry{vector: []float32{1.0}}
+
+	err := index.Delete(ctx, id)
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_DeleteBatchBeforeDeleteError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingBeforeDelete](provider)
+	ctx := context.Background()
+
+	err := index.DeleteBatch(ctx, []uuid.UUID{uuid.New()})
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_DeleteBatchAfterDeleteError(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[failingAfterDelete](provider)
+	ctx := context.Background()
+
+	err := index.DeleteBatch(ctx, []uuid.UUID{uuid.New()})
+	if !errors.Is(err, errHook) {
+		t.Fatalf("expected hook error, got: %v", err)
+	}
+}
+
+func TestIndexHooks_NoHookType(t *testing.T) {
+	provider := newMockVectorProvider()
+	index := NewIndex[testRecord](provider)
+	ctx := context.Background()
+
+	id := uuid.New()
+	meta := &testRecord{ID: 1, Name: "test"}
+	if err := index.Upsert(ctx, id, []float32{1.0}, meta); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result, err := index.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Metadata.Name != "test" {
+		t.Errorf("expected name 'test', got %q", result.Metadata.Name)
+	}
+}

--- a/pinecone/go.mod
+++ b/pinecone/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/zoobzio/dbml v1.0.0 // indirect
 	github.com/zoobzio/edamame v1.0.1 // indirect
 	github.com/zoobzio/sentinel v1.0.2 // indirect
-	github.com/zoobzio/soy v1.0.2 // indirect
+	github.com/zoobzio/soy v1.0.3 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/pinecone/go.sum
+++ b/pinecone/go.sum
@@ -49,7 +49,7 @@ github.com/zoobzio/edamame v1.0.1 h1:Mynav/EvOEVjQ36JrKm9I3k7nm9t3VgGC1bpyw2rFMA
 github.com/zoobzio/edamame v1.0.1/go.mod h1:UVfTcjd//Nfs2lLNWrQqomd0O9f0ic31PftXz3KvyWw=
 github.com/zoobzio/sentinel v1.0.2 h1:hTs5Ke2Vi0VgOkoHSJF9G3BYnxTQjMbvOH+qbbQLaoY=
 github.com/zoobzio/sentinel v1.0.2/go.mod h1:gtsD0AYlTEI8ajpEQ3azb7BDZicdsESOB1dJpQqgDKc=
-github.com/zoobzio/soy v1.0.2 h1:nNymMAvjZRJ1rHJFDDOCTFC7/mdKcgXuFE4JyAKT0FM=
+github.com/zoobzio/soy v1.0.3 h1:Qkl/v2XHv2bd/zo8YfVtIygKtzHclRwvXFnGVpRpwbg=
 github.com/zoobzio/vecna v0.0.2 h1:n4SEXmp1k5JrparT7PfPS6RTH4xd/NTkvXZwQg7r8/Q=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=

--- a/testing/go.mod
+++ b/testing/go.mod
@@ -179,7 +179,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zoobzio/capitan v1.0.0 // indirect
 	github.com/zoobzio/dbml v1.0.0 // indirect
-	github.com/zoobzio/soy v1.0.1 // indirect
+	github.com/zoobzio/soy v1.0.3 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0 // indirect

--- a/testing/go.sum
+++ b/testing/go.sum
@@ -720,8 +720,8 @@ github.com/zoobzio/edamame v1.0.1 h1:Mynav/EvOEVjQ36JrKm9I3k7nm9t3VgGC1bpyw2rFMA
 github.com/zoobzio/edamame v1.0.1/go.mod h1:UVfTcjd//Nfs2lLNWrQqomd0O9f0ic31PftXz3KvyWw=
 github.com/zoobzio/sentinel v1.0.2 h1:hTs5Ke2Vi0VgOkoHSJF9G3BYnxTQjMbvOH+qbbQLaoY=
 github.com/zoobzio/sentinel v1.0.2/go.mod h1:gtsD0AYlTEI8ajpEQ3azb7BDZicdsESOB1dJpQqgDKc=
-github.com/zoobzio/soy v1.0.1 h1:9PbD4rZtZDFa9n4dpVI0B4NdHDQ6xGSNLMOQZlVDWoQ=
-github.com/zoobzio/soy v1.0.1/go.mod h1:QbHYncFp2bUBfZegzSrTAcDoFKlLGQESKNY43OUu5q4=
+github.com/zoobzio/soy v1.0.3 h1:Qkl/v2XHv2bd/zo8YfVtIygKtzHclRwvXFnGVpRpwbg=
+github.com/zoobzio/soy v1.0.3/go.mod h1:QbHYncFp2bUBfZegzSrTAcDoFKlLGQESKNY43OUu5q4=
 github.com/zoobzio/vecna v0.0.2 h1:n4SEXmp1k5JrparT7PfPS6RTH4xd/NTkvXZwQg7r8/Q=
 github.com/zoobzio/vecna v0.0.2/go.mod h1:NQxYrpZSp8Lxqk5n8f3UB95bqMdG1g+tF1Sxxawds6Y=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=

--- a/testing/integration/bucket/azure/azure_test.go
+++ b/testing/integration/bucket/azure/azure_test.go
@@ -120,3 +120,7 @@ func TestAzure_Atomic(t *testing.T) {
 func TestAzure_List(t *testing.T) {
 	bucket.RunListTests(t, tc)
 }
+
+func TestAzure_Hooks(t *testing.T) {
+	bucket.RunHookTests(t, tc)
+}

--- a/testing/integration/bucket/gcs/gcs_test.go
+++ b/testing/integration/bucket/gcs/gcs_test.go
@@ -100,3 +100,7 @@ func TestGCS_Atomic(t *testing.T) {
 func TestGCS_List(t *testing.T) {
 	bucket.RunListTests(t, tc)
 }
+
+func TestGCS_Hooks(t *testing.T) {
+	bucket.RunHookTests(t, tc)
+}

--- a/testing/integration/bucket/s3/s3_test.go
+++ b/testing/integration/bucket/s3/s3_test.go
@@ -115,3 +115,7 @@ func TestS3_Atomic(t *testing.T) {
 func TestS3_List(t *testing.T) {
 	bucket.RunListTests(t, tc)
 }
+
+func TestS3_Hooks(t *testing.T) {
+	bucket.RunHookTests(t, tc)
+}

--- a/testing/integration/database/mariadb/mariadb_test.go
+++ b/testing/integration/database/mariadb/mariadb_test.go
@@ -87,3 +87,7 @@ func TestMariaDB_Query(t *testing.T) {
 func TestMariaDB_Transaction(t *testing.T) {
 	database.RunTransactionTests(t, tc)
 }
+
+func TestMariaDB_Hooks(t *testing.T) {
+	database.RunHookTests(t, tc)
+}

--- a/testing/integration/database/mssql/mssql_test.go
+++ b/testing/integration/database/mssql/mssql_test.go
@@ -89,3 +89,7 @@ func TestMSSQL_Query(t *testing.T) {
 func TestMSSQL_Transaction(t *testing.T) {
 	database.RunTransactionTests(t, tc)
 }
+
+func TestMSSQL_Hooks(t *testing.T) {
+	database.RunHookTests(t, tc)
+}

--- a/testing/integration/database/postgres/postgres_test.go
+++ b/testing/integration/database/postgres/postgres_test.go
@@ -79,3 +79,7 @@ func TestPostgres_Query(t *testing.T) {
 func TestPostgres_Transaction(t *testing.T) {
 	database.RunTransactionTests(t, tc)
 }
+
+func TestPostgres_Hooks(t *testing.T) {
+	database.RunHookTests(t, tc)
+}

--- a/testing/integration/database/sqlite/sqlite_test.go
+++ b/testing/integration/database/sqlite/sqlite_test.go
@@ -51,3 +51,7 @@ func TestSQLite_Query(t *testing.T) {
 func TestSQLite_Transaction(t *testing.T) {
 	database.RunTransactionTests(t, tc)
 }
+
+func TestSQLite_Hooks(t *testing.T) {
+	database.RunHookTests(t, tc)
+}

--- a/testing/integration/kv/badger/badger_test.go
+++ b/testing/integration/kv/badger/badger_test.go
@@ -55,3 +55,7 @@ func TestBadger_TTL(t *testing.T) {
 func TestBadger_Batch(t *testing.T) {
 	kv.RunBatchTests(t, tc)
 }
+
+func TestBadger_Hooks(t *testing.T) {
+	kv.RunHookTests(t, tc)
+}

--- a/testing/integration/kv/bolt/bolt_test.go
+++ b/testing/integration/kv/bolt/bolt_test.go
@@ -52,3 +52,7 @@ func TestBolt_Atomic(t *testing.T) {
 func TestBolt_Batch(t *testing.T) {
 	kv.RunBatchTests(t, tc)
 }
+
+func TestBolt_Hooks(t *testing.T) {
+	kv.RunHookTests(t, tc)
+}

--- a/testing/integration/kv/redis/redis_test.go
+++ b/testing/integration/kv/redis/redis_test.go
@@ -72,3 +72,7 @@ func TestRedis_TTL(t *testing.T) {
 func TestRedis_Batch(t *testing.T) {
 	kv.RunBatchTests(t, tc)
 }
+
+func TestRedis_Hooks(t *testing.T) {
+	kv.RunHookTests(t, tc)
+}

--- a/testing/integration/vector/milvus/milvus_test.go
+++ b/testing/integration/vector/milvus/milvus_test.go
@@ -156,3 +156,7 @@ func TestMilvus_Query(t *testing.T) {
 func TestMilvus_Filter(t *testing.T) {
 	vector.RunFilterTests(t, tc, true)
 }
+
+func TestMilvus_Hooks(t *testing.T) {
+	vector.RunHookTests(t, tc)
+}

--- a/testing/integration/vector/pinecone/pinecone_test.go
+++ b/testing/integration/vector/pinecone/pinecone_test.go
@@ -131,3 +131,7 @@ func TestPinecone_Filter(t *testing.T) {
 	// Pinecone doesn't support metadata-only filtering
 	vector.RunFilterTests(t, tc, false)
 }
+
+func TestPinecone_Hooks(t *testing.T) {
+	vector.RunHookTests(t, tc)
+}

--- a/testing/integration/vector/qdrant/qdrant_test.go
+++ b/testing/integration/vector/qdrant/qdrant_test.go
@@ -121,3 +121,7 @@ func TestQdrant_Query(t *testing.T) {
 func TestQdrant_Filter(t *testing.T) {
 	vector.RunFilterTests(t, tc, true)
 }
+
+func TestQdrant_Hooks(t *testing.T) {
+	vector.RunHookTests(t, tc)
+}

--- a/testing/integration/vector/weaviate/weaviate_test.go
+++ b/testing/integration/vector/weaviate/weaviate_test.go
@@ -147,3 +147,7 @@ func TestWeaviate_Query(t *testing.T) {
 func TestWeaviate_Filter(t *testing.T) {
 	vector.RunFilterTests(t, tc, true)
 }
+
+func TestWeaviate_Hooks(t *testing.T) {
+	vector.RunHookTests(t, tc)
+}


### PR DESCRIPTION
  Add BeforeSave, AfterSave, AfterLoad, BeforeDelete, and AfterDelete
  interfaces that T can implement to hook into CRUD operations across
  Store, Bucket, Database, and Index wrappers. Hooks are opt-in via
  type assertion — types that don't implement them incur zero overhead.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks (BeforeSave, AfterSave, AfterLoad, BeforeDelete, AfterDelete) across storage layers to run pre/post operations.

* **Documentation**
  * Added comprehensive Lifecycle Hooks docs and API reference with examples, behavior and scope notes.

* **Tests**
  * Extensive unit and integration tests added to validate hook behavior across databases, KV, buckets, vectors, and indexes.

* **Chores**
  * Updated minor dependency versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->