### PR TITLE
fix: add nolint:revive to aggregation_test.go

### DIFF
--- a/internal/shared/aggregation_test.go
+++ b/internal/shared/aggregation_test.go
@@ -1,4 +1,4 @@
-package shared
+package shared //nolint:revive // internal shared package is intentional
 
 import (
 	"encoding/json"


### PR DESCRIPTION
## Summary

- Add missing `//nolint:revive` directive to `aggregation_test.go` package declaration

## Changes

One-line fix. The `internal/shared` package requires `//nolint:revive` on all files due to the package name lint rule. The test file added in #26 was missing it, causing the CI lint job to fail on main.

## Test Plan

- `golangci-lint run ./...` — 0 issues
- `go test -race ./internal/shared/...` — passes