### PR TITLE
fix: wrap soy.ErrNotFound in ExecSelect methods

### DIFF
--- a/database.go
+++ b/database.go
@@ -323,7 +323,14 @@ func (d *Database[T]) ExecSelect(ctx context.Context, stmt edamame.SelectStateme
 		}
 		return &value, nil
 	}
-	return d.executor.ExecSelect(ctx, stmt, params)
+	result, err := d.executor.ExecSelect(ctx, stmt, params)
+	if err != nil {
+		if errors.Is(err, soy.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return result, nil
 }
 
 // ExecUpdate executes an update statement.
@@ -433,7 +440,14 @@ func (d *Database[T]) ExecQueryTx(ctx context.Context, tx *sqlx.Tx, stmt edamame
 // Panics if the database was constructed from a provider.
 func (d *Database[T]) ExecSelectTx(ctx context.Context, tx *sqlx.Tx, stmt edamame.SelectStatement, params map[string]any) (*T, error) {
 	d.requireExecutor("ExecSelectTx")
-	return d.executor.ExecSelectTx(ctx, tx, stmt, params)
+	result, err := d.executor.ExecSelectTx(ctx, tx, stmt, params)
+	if err != nil {
+		if errors.Is(err, soy.ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return result, nil
 }
 
 // ExecUpdateTx executes an update statement within a transaction.

--- a/database_provider.go
+++ b/database_provider.go
@@ -129,6 +129,9 @@ func (p *databaseProvider[T]) ExecQuery(ctx context.Context, stmt edamame.QueryS
 func (p *databaseProvider[T]) ExecSelect(ctx context.Context, stmt edamame.SelectStatement, params map[string]any) ([]byte, error) {
 	result, err := p.executor.ExecSelect(ctx, stmt, params)
 	if err != nil {
+		if errors.Is(err, soy.ErrNotFound) {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	return p.codec.Encode(result)

--- a/database_test.go
+++ b/database_test.go
@@ -453,6 +453,28 @@ func TestDatabase_ExecUpdate(t *testing.T) {
 	}
 }
 
+func TestDatabase_ExecSelect_NotFound(t *testing.T) {
+	mockDB, _ := mockdb.New()
+	ctx := context.Background()
+
+	db := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
+
+	stmt := edamame.NewSelectStatement("by-email", "Find user by email", edamame.SelectSpec{
+		Where: []edamame.ConditionSpec{
+			{Field: "email", Operator: "=", Param: "email"},
+		},
+	})
+
+	// mockdb returns empty rows, which should result in ErrNotFound
+	_, err := db.ExecSelect(ctx, stmt, map[string]any{"email": "nonexistent@example.com"})
+	if err == nil {
+		t.Error("expected error for missing record")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
 func TestDatabase_ExecAggregate(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
@@ -827,6 +849,33 @@ func TestDatabase_ExecUpdateTx(t *testing.T) {
 	}
 	if !strings.Contains(query.Query, `"name"`) {
 		t.Errorf("expected name column in SET clause, got: %s", query.Query)
+	}
+}
+
+func TestDatabase_ExecSelectTx_NotFound(t *testing.T) {
+	mockDB, _ := mockdb.New()
+	ctx := context.Background()
+
+	db := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
+
+	tx, err := mockDB.BeginTxx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTxx failed: %v", err)
+	}
+	defer tx.Rollback()
+
+	stmt := edamame.NewSelectStatement("by-email", "Find user by email", edamame.SelectSpec{
+		Where: []edamame.ConditionSpec{
+			{Field: "email", Operator: "=", Param: "email"},
+		},
+	})
+
+	_, err = db.ExecSelectTx(ctx, tx, stmt, map[string]any{"email": "nonexistent@example.com"})
+	if err == nil {
+		t.Error("expected error for missing record")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
 	}
 }
 
@@ -1893,10 +1942,13 @@ func TestDatabaseProvider_ExecSelect(t *testing.T) {
 		},
 	})
 
-	// Will return error since mockdb returns empty rows
+	// mockdb returns empty rows, should result in ErrNotFound
 	_, err := provider.ExecSelect(ctx, stmt, map[string]any{"email": "test@example.com"})
 	if err == nil {
 		t.Error("expected error from empty mockdb")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
 	}
 
 	query, ok := capture.Last()

--- a/database_test.go
+++ b/database_test.go
@@ -475,6 +475,57 @@ func TestDatabase_ExecSelect_NotFound(t *testing.T) {
 	}
 }
 
+func TestDatabase_ExecSelect_WithData(t *testing.T) {
+	mockDB, _, cfg := mockdb.NewWithConfig()
+	ctx := context.Background()
+
+	db := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
+
+	cfg.SetRowData(&mockdb.RowData{
+		Columns: []string{"id", "email", "name", "age"},
+		Rows:    [][]any{{int64(1), "test@example.com", "Test", int64(25)}},
+	})
+	defer cfg.Reset()
+
+	stmt := edamame.NewSelectStatement("by-email", "Find user by email", edamame.SelectSpec{
+		Where: []edamame.ConditionSpec{
+			{Field: "email", Operator: "=", Param: "email"},
+		},
+	})
+
+	result, err := db.ExecSelect(ctx, stmt, map[string]any{"email": "test@example.com"})
+	if err != nil {
+		t.Fatalf("ExecSelect failed: %v", err)
+	}
+	if result.ID != 1 {
+		t.Errorf("ID mismatch: got %d", result.ID)
+	}
+}
+
+func TestDatabase_ExecSelect_QueryError(t *testing.T) {
+	mockDB, _, cfg := mockdb.NewWithConfig()
+	ctx := context.Background()
+
+	db := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
+
+	cfg.SetQueryErr(errors.New("connection error"))
+	defer cfg.Reset()
+
+	stmt := edamame.NewSelectStatement("by-email", "Find user by email", edamame.SelectSpec{
+		Where: []edamame.ConditionSpec{
+			{Field: "email", Operator: "=", Param: "email"},
+		},
+	})
+
+	_, err := db.ExecSelect(ctx, stmt, map[string]any{"email": "test@example.com"})
+	if err == nil {
+		t.Error("expected error")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("expected non-NotFound error for connection failures")
+	}
+}
+
 func TestDatabase_ExecAggregate(t *testing.T) {
 	mockDB, capture := mockdb.New()
 	ctx := context.Background()
@@ -876,6 +927,69 @@ func TestDatabase_ExecSelectTx_NotFound(t *testing.T) {
 	}
 	if !errors.Is(err, ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestDatabase_ExecSelectTx_WithData(t *testing.T) {
+	mockDB, _, cfg := mockdb.NewWithConfig()
+	ctx := context.Background()
+
+	db := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
+
+	tx, err := mockDB.BeginTxx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTxx failed: %v", err)
+	}
+	defer tx.Rollback()
+
+	cfg.SetRowData(&mockdb.RowData{
+		Columns: []string{"id", "email", "name", "age"},
+		Rows:    [][]any{{int64(1), "test@example.com", "Test", int64(25)}},
+	})
+	defer cfg.Reset()
+
+	stmt := edamame.NewSelectStatement("by-email", "Find user by email", edamame.SelectSpec{
+		Where: []edamame.ConditionSpec{
+			{Field: "email", Operator: "=", Param: "email"},
+		},
+	})
+
+	result, err := db.ExecSelectTx(ctx, tx, stmt, map[string]any{"email": "test@example.com"})
+	if err != nil {
+		t.Fatalf("ExecSelectTx failed: %v", err)
+	}
+	if result.ID != 1 {
+		t.Errorf("ID mismatch: got %d", result.ID)
+	}
+}
+
+func TestDatabase_ExecSelectTx_QueryError(t *testing.T) {
+	mockDB, _, cfg := mockdb.NewWithConfig()
+	ctx := context.Background()
+
+	db := NewDatabase[TestDBUser](mockDB, "test_users", testDBRenderer)
+
+	tx, err := mockDB.BeginTxx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTxx failed: %v", err)
+	}
+	defer tx.Rollback()
+
+	cfg.SetQueryErr(errors.New("connection error"))
+	defer cfg.Reset()
+
+	stmt := edamame.NewSelectStatement("by-email", "Find user by email", edamame.SelectSpec{
+		Where: []edamame.ConditionSpec{
+			{Field: "email", Operator: "=", Param: "email"},
+		},
+	})
+
+	_, err = db.ExecSelectTx(ctx, tx, stmt, map[string]any{"email": "test@example.com"})
+	if err == nil {
+		t.Error("expected error")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("expected non-NotFound error for connection failures")
 	}
 }
 
@@ -1957,6 +2071,29 @@ func TestDatabaseProvider_ExecSelect(t *testing.T) {
 	}
 	if !strings.Contains(query.Query, "SELECT") {
 		t.Errorf("expected SELECT query, got: %s", query.Query)
+	}
+}
+
+func TestDatabaseProvider_ExecSelect_QueryError(t *testing.T) {
+	mockDB, _, cfg := mockdb.NewWithConfig()
+	provider := NewDatabaseProvider[TestDBUser](mockDB, "test_users", testDBRenderer)
+	ctx := context.Background()
+
+	cfg.SetQueryErr(errors.New("connection error"))
+	defer cfg.Reset()
+
+	stmt := edamame.NewSelectStatement("by-email", "Find by email", edamame.SelectSpec{
+		Where: []edamame.ConditionSpec{
+			{Field: "email", Operator: "=", Param: "email"},
+		},
+	})
+
+	_, err := provider.ExecSelect(ctx, stmt, map[string]any{"email": "test@example.com"})
+	if err == nil {
+		t.Error("expected error")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Error("expected non-NotFound error for connection failures")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Database.ExecSelect` and `Database.ExecSelectTx` returned `soy.ErrNotFound` directly from the executor layer, causing `errors.Is(err, grub.ErrNotFound)` to fail
- `databaseProvider.ExecSelect` had the same leak
- Added the same `soy.ErrNotFound → grub.ErrNotFound` wrapping pattern used by `Get`/`GetTx`

Closes #28

## Test plan

- [x] `TestDatabase_ExecSelect_NotFound` — verifies wrapper maps to `grub.ErrNotFound`
- [x] `TestDatabase_ExecSelectTx_NotFound` — same for transaction variant
- [x] `TestDatabaseProvider_ExecSelect` — updated to assert `ErrNotFound`
- [x] All existing tests pass
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)